### PR TITLE
Add Zeroize and Drop implementations

### DIFF
--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 stream-cipher = "0.3"
 block-cipher-trait = "0.6"
-zeroize = { version = "*", optional = true }
+zeroize = { version = "0.8", optional = true }
 
 [dev-dependencies]
 aes = "0.3"

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 stream-cipher = "0.3"
 block-cipher-trait = "0.6"
-zeroize = { version = "0.8", optional = true }
+zeroize = { version = "0.9", optional = true }
 
 [dev-dependencies]
 aes = "0.3"

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 stream-cipher = "0.3"
 block-cipher-trait = "0.6"
+zeroize = { version = "*", optional = true }
 
 [dev-dependencies]
 aes = "0.3"

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 stream-cipher = "0.3"
 block-cipher-trait = "0.6"
-zeroize = { version = "*", optional = true }
+zeroize = { version = "0.8", optional = true }
 
 [dev-dependencies]
 aes = "0.3"

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 stream-cipher = "0.3"
 block-cipher-trait = "0.6"
-zeroize = { version = "0.8", optional = true }
+zeroize = { version = "0.9", optional = true }
 
 [dev-dependencies]
 aes = "0.3"

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 stream-cipher = "0.3"
 block-cipher-trait = "0.6"
+zeroize = { version = "*", optional = true }
 
 [dev-dependencies]
 aes = "0.3"

--- a/cfb8/src/lib.rs
+++ b/cfb8/src/lib.rs
@@ -51,15 +51,38 @@
 extern crate block_cipher_trait;
 pub extern crate stream_cipher;
 
+#[cfg(cargo_feature = "zeroize")]
+extern crate zeroize;
+
 use stream_cipher::{NewStreamCipher, StreamCipher, InvalidKeyNonceLength};
 use block_cipher_trait::BlockCipher;
 use block_cipher_trait::generic_array::GenericArray;
 use block_cipher_trait::generic_array::typenum::Unsigned;
 
+#[cfg(cargo_feature = "zeroize")]
+use zeroize::Zeroize;
+#[cfg(cargo_feature = "zeroize")]
+use std::ops::Drop;
+
 /// CFB self-synchronizing stream cipher instance.
 pub struct Cfb8<C: BlockCipher> {
     cipher: C,
     iv: GenericArray<u8, C::BlockSize>,
+}
+
+#[cfg(cargo_feature = "zeroize")]
+impl<C: Zeroize> Zeroize for Cfb8<C> {
+    fn zeroize(&mut self) {
+        self.cipher.zeroize();
+        self.iv.zeroize();
+    }
+}
+
+#[cfg(cargo_feature = "zeroize")]
+impl<C> Drop for Cfb8<C> {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
 }
 
 impl<C: BlockCipher> NewStreamCipher for Cfb8<C> {

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 stream-cipher = "0.3"
 block-cipher-trait = "0.6"
-zeroize = { version = "*", optional = true }
+zeroize = { version = "0.8", optional = true }
 
 [dev-dependencies]
 aes = "0.3"

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 stream-cipher = "0.3"
 block-cipher-trait = "0.6"
-zeroize = { version = "0.8", optional = true }
+zeroize = { version = "0.9", optional = true }
 
 [dev-dependencies]
 aes = "0.3"

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 stream-cipher = "0.3"
 block-cipher-trait = "0.6"
+zeroize = { version = "*", optional = true }
 
 [dev-dependencies]
 aes = "0.3"

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 stream-cipher = "0.3"
 block-cipher-trait = "0.6"
-zeroize = { version = "*", optional = true }
+zeroize = { version = "0.8", optional = true }
 
 [dev-dependencies]
 aes = "0.3"

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 stream-cipher = "0.3"
 block-cipher-trait = "0.6"
-zeroize = { version = "0.8", optional = true }
+zeroize = { version = "0.9", optional = true }
 
 [dev-dependencies]
 aes = "0.3"

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 stream-cipher = "0.3"
 block-cipher-trait = "0.6"
+zeroize = { version = "*", optional = true }
 
 [dev-dependencies]
 aes = "0.3"


### PR DESCRIPTION
This changeset uses the Zeroize crate combined with implementations of the Drop trait to ensure that sensitive cryptographic state information is zeroed out when cryptographic objects go out of scope.  This is a defense against leaking sensitive information into unallocated memory, which is a common bug in cryptographic implementations.