### PR TITLE
salsa20-family: Upgrade to zeroize v0.9

### DIFF
--- a/salsa20-family/Cargo.toml
+++ b/salsa20-family/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 block-cipher-trait = "0.6"
 stream-cipher = "0.3"
-zeroize = { version = "0.8", optional = true }
+zeroize = { version = "0.9", optional = true }
 
 [dev-dependencies]
 stream-cipher = { version = "0.3", features = ["dev"] }


### PR DESCRIPTION
I'm trying to phase out (and eventually yank) v0.8 for reasons it isn't impacted by: namely it included an implicit Drop impl in its custom derive support, and I'm trying to backtrack on that and ensure it's always explicit.

Before I yank it though, I want to ensure existing users are up-to-date. 