### PR TITLE
Add #[ignore] attribute to tests that take excessively long to run

### DIFF
--- a/chacha20/tests/chacha20.rs
+++ b/chacha20/tests/chacha20.rs
@@ -313,6 +313,7 @@ fn chacha20_long() {
 }
 
 #[test]
+#[ignore]
 fn chacha20_offsets() {
     for idx in 0..256 {
         for middle in idx..256 {

--- a/salsa20/tests/salsa20.rs
+++ b/salsa20/tests/salsa20.rs
@@ -137,6 +137,7 @@ fn salsa20_long() {
 }
 
 #[test]
+#[ignore]
 fn salsa20_offsets() {
     for idx in 0..256 {
         for middle in idx..256 {


### PR DESCRIPTION
The `salsa20_offsets` and `chacha20_offsets` tests take an excessively long time to run (over a minute... I didn't bother to see how long they actually take because I got bored), slowing down both development and CI times.

Adding an `#[ignore]` attribute allows them to still be run with:

    $ cargo test -- --ignored

That way they can still be run if desired, but don't slow down development or CI unnecessarily.