### PR TITLE
Fix broken Cargo feature attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,6 @@ matrix:
         - rustup target add thumbv7em-none-eabihf
       script:
         - cargo build --all --target thumbv7em-none-eabihf --release
-    - name: "Rust: stable (wasm32-unknown-unknown)"
-      rust: stable
-      install:
-        - rustup target add wasm32-unknown-unknown
-      script:
-        - cargo build --all --target wasm32-unknown-unknown --release
     - name: rustfmt
       rust: stable
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: rust
 cache: cargo
 
 rust:
-  - 1.27.0
   - stable
   - nightly
 
@@ -18,6 +17,11 @@ matrix:
     - rust: nightly
   fast_finish: true
   include:
+    - name: "Rust: 1.27.0"
+      rust: 1.27.0
+      script:
+        - cargo test --all --release
+        - ./test_aesni.sh
     - name: "Rust: stable (thumbv7em-none-eabihf)"
       rust: stable
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,49 @@
 language: rust
-services: docker
-sudo: required
+cache: cargo
 
-matrix:
-  include:
-    - rust: 1.27.0
-    - rust: stable
-    - rust: nightly
+rust:
+  - 1.27.0
+  - stable
+  - nightly
+
+install:
+  - rustup component add rustfmt
+  - rustup component add clippy
+  - rustup target add thumbv7em-none-eabihf
+  - rustup target add wasm32-unknown-unknown
 
 script:
-  - cargo test --all ; ./test_aesni.sh
+  - cargo test --all --release
+  - cargo test --all --all-features --release
 
-cache: cargo
+matrix:
+  allow_failures:
+    - rust: nightly
+  include:
+    - name: "Rust: stable (thumbv7em-none-eabihf)"
+      rust: stable
+      script:
+        - cargo build --all --target thumbv7em-none-eabihf --release
+    - name: "Rust: stable (wasm32-unknown-unknown)"
+      rust: stable
+      script:
+        - cargo build --all --target wasm32-unknown-unknown --release
+    - name: "./test_aesni.sh"
+      rust: stable
+      script:
+        - ./test_aesni.sh
+    - name: rustfmt
+      rust: stable
+      script:
+        - cargo fmt --all -- --check
+    - name: clippy
+      rust: stable
+      script:
+        - cargo clippy --all
+    - name: docs
+      script:
+        - cargo doc --all --no-deps
+
+branches:
+  only:
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,10 @@ script:
 
 matrix:
   allow_failures:
+    - name: rustfmt
+    - name: clippy
     - rust: nightly
+  fast_finish: true
   include:
     - name: "Rust: stable (thumbv7em-none-eabihf)"
       rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,6 @@ matrix:
         - rustup component add clippy
       script:
         - cargo clippy --all
-    - name: docs
-      script:
-        - cargo doc --all --no-deps
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,10 @@ rust:
   - stable
   - nightly
 
-install:
-  - rustup component add rustfmt
-  - rustup component add clippy
-  - rustup target add thumbv7em-none-eabihf
-  - rustup target add wasm32-unknown-unknown
-
 script:
   - cargo test --all --release
   - cargo test --all --all-features --release
+  - ./test_aesni.sh
 
 matrix:
   allow_failures:
@@ -25,22 +20,26 @@ matrix:
   include:
     - name: "Rust: stable (thumbv7em-none-eabihf)"
       rust: stable
+      install:
+        - rustup target add thumbv7em-none-eabihf
       script:
         - cargo build --all --target thumbv7em-none-eabihf --release
     - name: "Rust: stable (wasm32-unknown-unknown)"
       rust: stable
+      install:
+        - rustup target add wasm32-unknown-unknown
       script:
         - cargo build --all --target wasm32-unknown-unknown --release
-    - name: "./test_aesni.sh"
-      rust: stable
-      script:
-        - ./test_aesni.sh
     - name: rustfmt
       rust: stable
+      install:
+        - rustup component add rustfmt
       script:
         - cargo fmt --all -- --check
     - name: clippy
       rust: stable
+      install:
+        - rustup component add clippy
       script:
         - cargo clippy --all
     - name: docs

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -3,14 +3,14 @@ extern crate block_cipher_trait;
 extern crate salsa20_core;
 extern crate stream_cipher;
 
-#[cfg(cargo_feature = "zeroize")]
+#[cfg(feature = "zeroize")]
 extern crate zeroize;
 
 use block_cipher_trait::generic_array::typenum::{U12, U32, U8};
 use block_cipher_trait::generic_array::{ArrayLength, GenericArray};
 use stream_cipher::{NewStreamCipher, StreamCipher, SyncStreamCipherSeek};
 
-#[cfg(cargo_feature = "zeroize")]
+#[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
 
 use salsa20_core::{SalsaFamilyCipher, SalsaFamilyState};
@@ -182,7 +182,7 @@ impl<N: ArrayLength<u8>> SyncStreamCipherSeek for ChaChaState<N> {
     }
 }
 
-#[cfg(cargo_feature = "zeroize")]
+#[cfg(feature = "zeroize")]
 impl Zeroize for ChaChaState {
     fn zeroize(&mut self) {
         self.state.zeroize();
@@ -267,7 +267,7 @@ impl<N: ArrayLength<u8>> StreamCipher for ChaCha20<N> {
     }
 }
 
-#[cfg(cargo_feature = "zeroize")]
+#[cfg(feature = "zeroize")]
 impl Zeroize for ChaCha20 {
     fn zeroize(&mut self) {
         self.state.zeroize();

--- a/salsa20-core/src/lib.rs
+++ b/salsa20-core/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate block_cipher_trait;
 
-#[cfg(cargo_feature = "zeroize")]
+#[cfg(feature = "zeroize")]
 extern crate zeroize;
 
 pub extern crate stream_cipher;

--- a/salsa20-core/src/lib.rs
+++ b/salsa20-core/src/lib.rs
@@ -1,10 +1,10 @@
 #![no_std]
+
 extern crate block_cipher_trait;
 
 #[cfg(cargo_feature = "zeroize")]
 extern crate zeroize;
 
-pub extern crate std;
 pub extern crate stream_cipher;
 
 mod salsa_family_state;

--- a/salsa20-core/src/salsa_family_state.rs
+++ b/salsa20-core/src/salsa_family_state.rs
@@ -4,9 +4,9 @@ use block_cipher_trait::generic_array::GenericArray;
 use stream_cipher::NewStreamCipher;
 use stream_cipher::SyncStreamCipherSeek;
 
-#[cfg(cargo_feature = "zeroize")]
+#[cfg(feature = "zeroize")]
 use std::ops::Drop;
-#[cfg(cargo_feature = "zeroize")]
+#[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
 
 const KEY_BITS: usize = 256;
@@ -244,7 +244,7 @@ impl SyncStreamCipherSeek for SalsaFamilyState {
     }
 }
 
-#[cfg(cargo_feature = "zeroize")]
+#[cfg(feature = "zeroize")]
 impl Zeroize for SalsaFamilyState {
     fn zeroize(&mut self) {
         self.block.zeroize();
@@ -255,7 +255,7 @@ impl Zeroize for SalsaFamilyState {
     }
 }
 
-#[cfg(cargo_feature = "zeroize")]
+#[cfg(feature = "zeroize")]
 impl Drop for SalsaFamilyState {
     fn drop(&mut self) {
         self.zeroize();

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -4,14 +4,14 @@ extern crate block_cipher_trait;
 extern crate salsa20_core;
 extern crate stream_cipher;
 
-#[cfg(cargo_feature = "zeroize")]
+#[cfg(feature = "zeroize")]
 extern crate zeroize;
 
 use block_cipher_trait::generic_array::typenum::{U32, U8};
 use block_cipher_trait::generic_array::GenericArray;
 use stream_cipher::{NewStreamCipher, StreamCipher, SyncStreamCipherSeek};
 
-#[cfg(cargo_feature = "zeroize")]
+#[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
 
 use salsa20_core::{SalsaFamilyCipher, SalsaFamilyState};
@@ -202,7 +202,7 @@ impl SyncStreamCipherSeek for SalsaState {
     }
 }
 
-#[cfg(cargo_feature = "zeroize")]
+#[cfg(feature = "zeroize")]
 impl Zeroize for SalsaState {
     fn zeroize(&mut self) {
         self.state.zeroize();
@@ -270,7 +270,7 @@ impl StreamCipher for Salsa20 {
     }
 }
 
-#[cfg(cargo_feature = "zeroize")]
+#[cfg(feature = "zeroize")]
 impl Zeroize for Salsa20 {
     fn zeroize(&mut self) {
         self.state.zeroize();


### PR DESCRIPTION
*Note: This includes commits from #21, which should get (squashed/)merged first.*

Several things were gated under `#[cfg(cargo_feature=...)]` attributes, which don't appear to do anything. Because of it, much of it was broken/untested.