### PR TITLE
.travis.yml: Run --ignored tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rust:
 script:
   - cargo test --all --release
   - cargo test --all --all-features --release
+  - cargo test --all --all-features --release -- --ignored
   - ./test_aesni.sh
 
 env:


### PR DESCRIPTION
...with the `--release` flag so they should be comparatively quick versus the excessively long time they take without it.

I think it's a nice tradeoff to have these run in CI with `--release`, but avoid switching local development to excessively optimize in debug mode just for these particular tests.