### PR TITLE
salsa20-core: Address `word_idx`-related warning (closes #23)

### DIFF
--- a/salsa20-core/src/salsa_family_state.rs
+++ b/salsa20-core/src/salsa_family_state.rs
@@ -90,17 +90,9 @@ pub trait SalsaFamilyCipher {
                                 i += 1;
                             }
                         }
-
-                        self.next_block();
-                    } else {
-                        // TODO(tarcieri): is this else clause unnecessary or is there a bug?
-                        // See: <https://github.com/RustCrypto/stream-ciphers/issues/23>
-                        #[allow(unused_assignments)]
-                        {
-                            word_idx = 0;
-                            self.next_block();
-                        }
                     }
+
+                    self.next_block();
 
                     let nblocks = (datalen - i) / 64;
                     let leftover = (datalen - i) % 64;


### PR DESCRIPTION
As far as I can tell setting `word_idx` here accomplishes nothing as it's never read in the remainder of the function.

It was originally added in this commit, and as far as I can tell has always been a spurious assignment:

https://github.com/RustCrypto/stream-ciphers/commit/8572ba4#diff-e39e303466eee7b7ea454eb1e2faec3cR94