### PR TITLE
Fix trivial clippy warnings

### DIFF
--- a/ctr/src/lib.rs
+++ b/ctr/src/lib.rs
@@ -191,7 +191,7 @@ impl<C> SyncStreamCipher for Ctr128<C>
             counter += 1;
         }
 
-        if data.len() != 0 {
+        if !data.is_empty() {
             self.block = self.generate_block(counter);
             counter += 1;
             let n = data.len();
@@ -213,7 +213,7 @@ impl<C> SyncStreamCipherSeek for Ctr128<C>
     fn current_pos(&self) -> u64 {
         let bs = Self::block_size() as u64;
         match self.pos {
-            Some(pos) => self.counter.wrapping_sub(1)*bs + pos as u64,
+            Some(pos) => self.counter.wrapping_sub(1)*bs + u64::from(pos),
             None => self.counter*bs,
         }
     }

--- a/salsa20-core/src/lib.rs
+++ b/salsa20-core/src/lib.rs
@@ -42,16 +42,12 @@ pub struct SalsaFamilyState {
 }
 
 pub trait SalsaFamilyCipher {
-    #[inline]
     fn next_block(&mut self);
 
-    #[inline]
     fn offset(&self) -> usize;
 
-    #[inline]
     fn set_offset(&mut self, offset: usize);
 
-    #[inline]
     fn block_word(&self, idx: usize) -> u32;
 
     fn process(&mut self, data: &mut [u8]) {
@@ -75,7 +71,7 @@ pub trait SalsaFamilyCipher {
                 let word = self.block_word(initial_word_idx);
 
                 for j in initial_word_offset..4 {
-                    data[i] = data[i] ^ ((word >> (j * 8)) & 0xff) as u8;
+                    data[i] ^= ((word >> (j * 8)) & 0xff) as u8;
                     i += 1;
                 }
 
@@ -94,7 +90,7 @@ pub trait SalsaFamilyCipher {
                             let word = self.block_word(j);
 
                             for k in 0..4 {
-                                data[i] = data[i] ^ ((word >> (k * 8)) & 0xff) as u8;
+                                data[i] ^= ((word >> (k * 8)) & 0xff) as u8;
                                 i += 1;
                             }
                         }
@@ -111,7 +107,7 @@ pub trait SalsaFamilyCipher {
                             let word = self.block_word(j);
 
                             for k in 0..4 {
-                                data[i] = data[i] ^ ((word >> (k * 8)) & 0xff) as u8;
+                                data[i] ^= ((word >> (k * 8)) & 0xff) as u8;
                                 i += 1;
                             }
                         }
@@ -126,7 +122,7 @@ pub trait SalsaFamilyCipher {
                         let word = self.block_word(j);
 
                         for k in 0..4 {
-                            data[i] = data[i] ^ ((word >> (k * 8)) & 0xff) as u8;
+                            data[i] ^= ((word >> (k * 8)) & 0xff) as u8;
                             i += 1;
                         }
                     }
@@ -150,7 +146,7 @@ pub trait SalsaFamilyCipher {
                         let word = self.block_word(j);
 
                         for k in 0..4 {
-                            data[i] = data[i] ^ ((word >> (k * 8)) & 0xff) as u8;
+                            data[i] ^= ((word >> (k * 8)) & 0xff) as u8;
                             i += 1;
                         }
                     }
@@ -166,7 +162,7 @@ pub trait SalsaFamilyCipher {
             let word = self.block_word(leftover_words);
 
             for j in 0..leftover_bytes {
-                data[i] = data[i] ^ ((word >> (j * 8)) & 0xff) as u8;
+                data[i] ^= ((word >> (j * 8)) & 0xff) as u8;
                 i += 1;
             }
 
@@ -178,7 +174,7 @@ pub trait SalsaFamilyCipher {
             let word = self.block_word(word_idx);
 
             for j in initial_word_offset..initial_word_offset + datalen {
-                data[i] = data[i] ^ ((word >> (j * 8)) & 0xff) as u8;
+                data[i] ^= ((word >> (j * 8)) & 0xff) as u8;
                 i += 1;
             }
 
@@ -205,17 +201,17 @@ impl SalsaFamilyState {
 
     pub fn init(&mut self, key: &[u8], iv: &[u8], block_idx: u64, offset: usize) {
         for i in 0..KEY_WORDS {
-            self.key[i] = key[4 * i] as u32 & 0xff
-                | (key[(4 * i) + 1] as u32 & 0xff) << 8
-                | (key[(4 * i) + 2] as u32 & 0xff) << 16
-                | (key[(4 * i) + 3] as u32 & 0xff) << 24;
+            self.key[i] = u32::from(key[4 * i]) & 0xff
+                | (u32::from(key[(4 * i) + 1]) & 0xff) << 8
+                | (u32::from(key[(4 * i) + 2]) & 0xff) << 16
+                | (u32::from(key[(4 * i) + 3]) & 0xff) << 24;
         }
 
         for i in 0..IV_WORDS {
-            self.iv[i] = iv[4 * i] as u32 & 0xff
-                | (iv[(4 * i) + 1] as u32 & 0xff) << 8
-                | (iv[(4 * i) + 2] as u32 & 0xff) << 16
-                | (iv[(4 * i) + 3] as u32 & 0xff) << 24;
+            self.iv[i] = u32::from(iv[4 * i]) & 0xff
+                | (u32::from(iv[(4 * i) + 1]) & 0xff) << 8
+                | (u32::from(iv[(4 * i) + 2]) & 0xff) << 16
+                | (u32::from(iv[(4 * i) + 3]) & 0xff) << 24;
         }
 
         self.block_idx = block_idx;

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -112,22 +112,22 @@ impl SalsaState {
         let key = self.state.key;
         let block_idx = self.state.block_idx;
 
-        block[0] = 0x61707865;
+        block[0] = 0x6170_7865;
         block[1] = key[0];
         block[2] = key[1];
         block[3] = key[2];
         block[4] = key[3];
-        block[5] = 0x3320646e;
+        block[5] = 0x3320_646e;
         block[6] = iv[0];
         block[7] = iv[1];
-        block[8] = (block_idx & 0xffffffff) as u32;
-        block[9] = ((block_idx >> 32) & 0xffffffff) as u32;
-        block[10] = 0x79622d32;
+        block[8] = (block_idx & 0xffff_ffff) as u32;
+        block[9] = ((block_idx >> 32) & 0xffff_ffff) as u32;
+        block[10] = 0x7962_2d32;
         block[11] = key[4];
         block[12] = key[5];
         block[13] = key[6];
         block[14] = key[7];
-        block[15] = 0x6b206574;
+        block[15] = 0x6b20_6574;
     }
 
     #[inline]
@@ -137,22 +137,22 @@ impl SalsaState {
         let key = self.state.key;
         let block_idx = self.state.block_idx;
 
-        block[0] = block[0].wrapping_add(0x61707865);
+        block[0] = block[0].wrapping_add(0x6170_7865);
         block[1] = block[1].wrapping_add(key[0]);
         block[2] = block[2].wrapping_add(key[1]);
         block[3] = block[3].wrapping_add(key[2]);
         block[4] = block[4].wrapping_add(key[3]);
-        block[5] = block[5].wrapping_add(0x3320646e);
+        block[5] = block[5].wrapping_add(0x3320_646e);
         block[6] = block[6].wrapping_add(iv[0]);
         block[7] = block[7].wrapping_add(iv[1]);
-        block[8] = block[8].wrapping_add((block_idx & 0xffffffff) as u32);
-        block[9] = block[9].wrapping_add(((block_idx >> 32) & 0xffffffff) as u32);
-        block[10] = block[10].wrapping_add(0x79622d32);
+        block[8] = block[8].wrapping_add((block_idx & 0xffff_ffff) as u32);
+        block[9] = block[9].wrapping_add(((block_idx >> 32) & 0xffff_ffff) as u32);
+        block[10] = block[10].wrapping_add(0x7962_2d32);
         block[11] = block[11].wrapping_add(key[4]);
         block[12] = block[12].wrapping_add(key[5]);
         block[13] = block[13].wrapping_add(key[6]);
         block[14] = block[14].wrapping_add(key[7]);
-        block[15] = block[15].wrapping_add(0x6b206574);
+        block[15] = block[15].wrapping_add(0x6b20_6574);
     }
 }
 


### PR DESCRIPTION
This fixes all of the clippy warnings which have trivial corrections.

There's one remaining one involving an unsafe pointer cast that's a little more thorny which I'd like to address separately.