### PR TITLE
ctr: Use `byteorder` crate for endianness conversions

### DIFF
--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["crypto", "stream-cipher", "trait"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
+byteorder = { version = "1", default-features = false }
 stream-cipher = "0.3"
 block-cipher-trait = "0.6"
 


### PR DESCRIPTION
clippy was not a fan of the previous unsafe conversion:

```
error: casting from `*const stream_cipher::generic_array::GenericArray<u8, stream_cipher::generic_array::typenum::UInt<stream_cipher::generic_array::typenum::UInt<stream_cipher::generic_array::typenum::UInt<stream_cipher::generic_array::typenum::UInt<stream_cipher::generic_array::typenum::UInt<stream_cipher::generic_array::typenum::UTerm, stream_cipher::generic_array::typenum::B1>, stream_cipher::generic_array::typenum::B0>, stream_cipher::generic_array::typenum::B0>, stream_cipher::generic_array::typenum::B0>, stream_cipher::generic_array::typenum::B0>>` to a more-strictly-aligned pointer (`*const [u64; 2]`)
  --> ctr/src/lib.rs:90:17
   |
90 |                 nonce as *const Nonce<Self> as *const [u64; 2]
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[deny(clippy::cast_ptr_alignment)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_ptr_alignment
```

This is the last clippy warning. We should be green after this.