### PR TITLE
Add #![deny(missing_docs)] to all crates

### DIFF
--- a/aes-ctr/src/lib.rs
+++ b/aes-ctr/src/lib.rs
@@ -37,6 +37,7 @@
 //! assert_eq!(data, [1, 2, 3, 4, 5, 6, 7]);
 //! ```
 #![no_std]
+#![deny(missing_docs)]
 #[cfg(not(all(
     target_feature = "aes",
     target_feature = "sse2",

--- a/cfb-mode/src/lib.rs
+++ b/cfb-mode/src/lib.rs
@@ -46,6 +46,7 @@
 //! [1]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#CFB
 //! [2]: https://en.wikipedia.org/wiki/Stream_cipher#Self-synchronizing_stream_ciphers
 #![no_std]
+#![deny(missing_docs)]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 extern crate block_cipher_trait;
 pub extern crate stream_cipher;

--- a/cfb8/src/lib.rs
+++ b/cfb8/src/lib.rs
@@ -46,6 +46,7 @@
 //! [1]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#CFB
 //! [2]: https://en.wikipedia.org/wiki/Stream_cipher#Self-synchronizing_stream_ciphers
 #![no_std]
+#![deny(missing_docs)]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 extern crate block_cipher_trait;
 pub extern crate stream_cipher;

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -1,4 +1,8 @@
+//! The ChaCha20 stream cipher
+
 #![no_std]
+#![deny(missing_docs)]
+
 extern crate block_cipher_trait;
 extern crate salsa20_core;
 extern crate stream_cipher;

--- a/ctr/src/lib.rs
+++ b/ctr/src/lib.rs
@@ -38,6 +38,7 @@
 //! # }
 //! ```
 #![no_std]
+#![deny(missing_docs)]
 extern crate block_cipher_trait;
 pub extern crate stream_cipher;
 

--- a/ofb/src/lib.rs
+++ b/ofb/src/lib.rs
@@ -48,6 +48,7 @@
 //! [1]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#OFB
 //! [2]: https://en.wikipedia.org/wiki/Stream_cipher#Synchronous_stream_ciphers
 #![no_std]
+#![deny(missing_docs)]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 extern crate block_cipher_trait;
 pub extern crate stream_cipher;

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -1,4 +1,7 @@
+//! The Salsa20 stream cipher
+
 #![no_std]
+#![deny(missing_docs)]
 
 extern crate block_cipher_trait;
 extern crate salsa20_core;


### PR DESCRIPTION
...and add some basic documentation to crates with missing docs.

The Salsa20 Family crates could probably use a bit more documentation than this, but this is a start.