### PR TITLE
salsa20: Refactor to eliminate needless wrapper structs

### DIFF
--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -13,11 +13,13 @@ readme = "README.md"
 block-cipher-trait = "0.6"
 stream-cipher = "0.3"
 salsa20-core = { version = "0.1", path = "../salsa20-core"}
-zeroize = { version = "0.9", optional = true }
 
 [dev-dependencies]
 stream-cipher = { version = "0.3", features = ["dev"] }
 block-cipher-trait = { version = "0.6", features = ["dev"] }
+
+[features]
+zeroize = ["salsa20-core/zeroize"]
 
 [badges]
 travis-ci = { repository = "RustCrypto/stream-ciphers" }


### PR DESCRIPTION
For whatever reason this previously had a superfluous wrapper struct.

This refactor removes it.

Also, as `salsa20-core` already handles `zeroize`, like the corresponding change to the ChaCha20 crate this makes `zeroize` into a cargo feature which enables the corresponding feature on `salsa20-core`.