### PR TITLE
impl SyncStreamCipher for Salsa20 and ChaCha20

### DIFF
--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -22,7 +22,7 @@
 //! ```
 //! use chacha20::ChaCha20;
 //! use chacha20::stream_cipher::generic_array::GenericArray;
-//! use chacha20::stream_cipher::{NewStreamCipher, StreamCipher};
+//! use chacha20::stream_cipher::{NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
 //!
 //! let mut data = [1, 2, 3, 4, 5, 6, 7];
 //!
@@ -32,15 +32,13 @@
 //! // create cipher instance
 //! let mut cipher = ChaCha20::new(&key, &nonce);
 //!
-//! // encrypt data
-//! cipher.encrypt(&mut data);
+//! // apply keystream (encrypt)
+//! cipher.apply_keystream(&mut data);
 //! assert_eq!(data, [73, 98, 234, 202, 73, 143, 0]);
 //!
-//! // (re)create cipher instance
-//! let mut cipher = ChaCha20::new(&key, &nonce);
-//!
-//! // decrypt data
-//! cipher.decrypt(&mut data);
+//! // seek to the keystream beginning and apply it again to the `data` (decrypt)
+//! cipher.seek(0);
+//! cipher.apply_keystream(&mut data);
 //! assert_eq!(data, [1, 2, 3, 4, 5, 6, 7]);
 //! ```
 //!
@@ -63,7 +61,7 @@ mod xchacha20;
 use block_cipher_trait::generic_array::typenum::{U12, U32, U8};
 use block_cipher_trait::generic_array::{ArrayLength, GenericArray};
 use salsa20_core::{SalsaFamilyCipher, SalsaFamilyState};
-use stream_cipher::{NewStreamCipher, StreamCipher, SyncStreamCipherSeek};
+use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
 
 #[cfg(feature = "xchacha20")]
 pub use self::xchacha20::XChaCha20;
@@ -121,6 +119,7 @@ impl_chacha20!(ChaCha20, U12);
 impl_chacha20!(ChaCha20Legacy, U8);
 
 /// Wrapper for state for ChaCha-type ciphers.
+#[derive(Debug)]
 pub struct ChaChaState<N: ArrayLength<u8>> {
     state: SalsaFamilyState,
     phantom: core::marker::PhantomData<N>,
@@ -150,7 +149,7 @@ impl<N: ArrayLength<u8>> ChaChaState<N> {
 
     #[inline]
     fn double_round(&mut self) {
-        let block = &mut self.state.block;
+        let block = self.state.block_mut();
 
         quarter_round(0, 4, 8, 12, block);
         quarter_round(1, 5, 9, 13, block);
@@ -163,36 +162,11 @@ impl<N: ArrayLength<u8>> ChaChaState<N> {
     }
 
     #[inline]
-    fn add_block(&mut self) {
-        let block = &mut self.state.block;
-        let iv = self.state.iv;
-        let key = self.state.key;
-        let block_idx = self.state.block_idx;
-
-        block[0] = block[0].wrapping_add(0x6170_7865);
-        block[1] = block[1].wrapping_add(0x3320_646e);
-        block[2] = block[2].wrapping_add(0x7962_2d32);
-        block[3] = block[3].wrapping_add(0x6b20_6574);
-        block[4] = block[4].wrapping_add(key[0]);
-        block[5] = block[5].wrapping_add(key[1]);
-        block[6] = block[6].wrapping_add(key[2]);
-        block[7] = block[7].wrapping_add(key[3]);
-        block[8] = block[8].wrapping_add(key[4]);
-        block[9] = block[9].wrapping_add(key[5]);
-        block[10] = block[10].wrapping_add(key[6]);
-        block[11] = block[11].wrapping_add(key[7]);
-        block[12] = block[12].wrapping_add((block_idx & 0xffff_ffff) as u32);
-        block[13] = block[13].wrapping_add(((block_idx >> 32) & 0xffff_ffff) as u32);
-        block[14] = block[14].wrapping_add(iv[0]);
-        block[15] = block[15].wrapping_add(iv[1]);
-    }
-
-    #[inline]
     fn init_block(&mut self) {
-        let block = &mut self.state.block;
-        let iv = self.state.iv;
-        let key = self.state.key;
-        let block_idx = self.state.block_idx;
+        let iv = self.state.iv();
+        let key = self.state.key();
+        let block_idx = self.state.block_idx();
+        let block = self.state.block_mut();
 
         block[0] = 0x6170_7865;
         block[1] = 0x3320_646e;
@@ -210,6 +184,31 @@ impl<N: ArrayLength<u8>> ChaChaState<N> {
         block[13] = ((block_idx >> 32) & 0xffff_ffff) as u32;
         block[14] = iv[0];
         block[15] = iv[1];
+    }
+
+    #[inline]
+    fn add_block(&mut self) {
+        let iv = self.state.iv();
+        let key = self.state.key();
+        let block_idx = self.state.block_idx();
+        let block = self.state.block_mut();
+
+        block[0] = block[0].wrapping_add(0x6170_7865);
+        block[1] = block[1].wrapping_add(0x3320_646e);
+        block[2] = block[2].wrapping_add(0x7962_2d32);
+        block[3] = block[3].wrapping_add(0x6b20_6574);
+        block[4] = block[4].wrapping_add(key[0]);
+        block[5] = block[5].wrapping_add(key[1]);
+        block[6] = block[6].wrapping_add(key[2]);
+        block[7] = block[7].wrapping_add(key[3]);
+        block[8] = block[8].wrapping_add(key[4]);
+        block[9] = block[9].wrapping_add(key[5]);
+        block[10] = block[10].wrapping_add(key[6]);
+        block[11] = block[11].wrapping_add(key[7]);
+        block[12] = block[12].wrapping_add((block_idx & 0xffff_ffff) as u32);
+        block[13] = block[13].wrapping_add(((block_idx >> 32) & 0xffff_ffff) as u32);
+        block[14] = block[14].wrapping_add(iv[0]);
+        block[15] = block[15].wrapping_add(iv[1]);
     }
 }
 
@@ -238,45 +237,58 @@ impl NewStreamCipher for ChaChaState<U12> {
     fn new(key: &GenericArray<u8, Self::KeySize>, iv: &GenericArray<u8, Self::NonceSize>) -> Self {
         let exp_iv = &iv[0..4];
         let base_iv = &iv[4..12];
-
-        let mut ccs = ChaChaState {
-            state: SalsaFamilyState::new(key, GenericArray::from_slice(base_iv)),
-            phantom: core::marker::PhantomData,
-        };
-
-        ccs.state.block_idx = (u64::from(exp_iv[0]) & 0xff) << 32
+        let block_idx = (u64::from(exp_iv[0]) & 0xff) << 32
             | (u64::from(exp_iv[1]) & 0xff) << 40
             | (u64::from(exp_iv[2]) & 0xff) << 48
             | (u64::from(exp_iv[3]) & 0xff) << 56;
 
-        ccs
+        let state =
+            SalsaFamilyState::new_with_idx(key, GenericArray::from_slice(base_iv), block_idx);
+
+        Self {
+            state,
+            phantom: core::marker::PhantomData,
+        }
     }
 }
 
 impl<N: ArrayLength<u8>> SalsaFamilyCipher for ChaChaState<N> {
     #[inline]
     fn next_block(&mut self) {
-        self.state.block_idx += 1;
+        self.state.next_block();
         self.gen_block();
     }
 
     #[inline]
     fn offset(&self) -> usize {
-        self.state.offset
+        self.state.offset()
     }
 
     #[inline]
     fn set_offset(&mut self, offset: usize) {
-        self.state.offset = offset;
+        self.state.set_offset(offset)
     }
 
     #[inline]
     fn block_word(&self, idx: usize) -> u32 {
-        self.state.block[idx]
+        self.state.block_word(idx)
     }
 }
 
-impl<N: ArrayLength<u8>> SyncStreamCipherSeek for ChaChaState<N> {
+impl<N> SyncStreamCipher for ChaChaState<N>
+where
+    N: ArrayLength<u8>,
+{
+    fn try_apply_keystream(&mut self, data: &mut [u8]) -> Result<(), LoopError> {
+        self.process(data);
+        Ok(())
+    }
+}
+
+impl<N> SyncStreamCipherSeek for ChaChaState<N>
+where
+    N: ArrayLength<u8>,
+{
     fn current_pos(&self) -> u64 {
         self.state.current_pos()
     }
@@ -284,16 +296,6 @@ impl<N: ArrayLength<u8>> SyncStreamCipherSeek for ChaChaState<N> {
     fn seek(&mut self, pos: u64) {
         self.state.seek(pos);
         self.gen_block();
-    }
-}
-
-impl<N: ArrayLength<u8>> StreamCipher for ChaChaState<N> {
-    fn encrypt(&mut self, data: &mut [u8]) {
-        self.process(data);
-    }
-
-    fn decrypt(&mut self, data: &mut [u8]) {
-        self.process(data);
     }
 }
 


### PR DESCRIPTION
Previously they only impl'd `StreamCipher`

Additionally this fixes bugs in the previous `SyncStreamCipherSeek` impls on both ciphers by better encapsulating the block index and offset management in the `SalsaFamilyCipher` type. This allows the crate examples to use this impl in the documented examples, which is consistent with the other crates.