### PR TITLE
chacha20: Extract and encapsulate Cipher type

### DIFF
--- a/chacha20/src/cipher.rs
+++ b/chacha20/src/cipher.rs
@@ -1,0 +1,170 @@
+//! ChaCha20 cipher core implementation
+
+use salsa20_core::{SalsaFamilyCipher, SalsaFamilyState};
+use stream_cipher::{LoopError, SyncStreamCipher, SyncStreamCipherSeek};
+
+/// ChaCha20 core cipher functionality
+#[derive(Debug)]
+pub struct Cipher {
+    state: SalsaFamilyState,
+}
+
+impl Cipher {
+    /// Create cipher with the given state
+    pub(crate) fn new(state: SalsaFamilyState) -> Self {
+        let mut cipher = Cipher { state };
+        cipher.gen_block();
+        cipher
+    }
+
+    /// Generate a block
+    pub(crate) fn gen_block(&mut self) {
+        self.init_block();
+        self.rounds();
+        self.add_block();
+    }
+
+    /// Run the 20 rounds (i.e. 10 double rounds) of ChaCha20
+    #[inline]
+    fn rounds(&mut self) {
+        self.double_round();
+        self.double_round();
+        self.double_round();
+        self.double_round();
+        self.double_round();
+
+        self.double_round();
+        self.double_round();
+        self.double_round();
+        self.double_round();
+        self.double_round();
+    }
+
+    /// Double round function
+    #[inline]
+    fn double_round(&mut self) {
+        let block = self.state.block_mut();
+
+        quarter_round(0, 4, 8, 12, block);
+        quarter_round(1, 5, 9, 13, block);
+        quarter_round(2, 6, 10, 14, block);
+        quarter_round(3, 7, 11, 15, block);
+        quarter_round(0, 5, 10, 15, block);
+        quarter_round(1, 6, 11, 12, block);
+        quarter_round(2, 7, 8, 13, block);
+        quarter_round(3, 4, 9, 14, block);
+    }
+
+    /// Initialize a new block
+    #[inline]
+    fn init_block(&mut self) {
+        let iv = self.state.iv();
+        let key = self.state.key();
+        let block_idx = self.state.block_idx();
+        let block = self.state.block_mut();
+
+        block[0] = 0x6170_7865;
+        block[1] = 0x3320_646e;
+        block[2] = 0x7962_2d32;
+        block[3] = 0x6b20_6574;
+        block[4] = key[0];
+        block[5] = key[1];
+        block[6] = key[2];
+        block[7] = key[3];
+        block[8] = key[4];
+        block[9] = key[5];
+        block[10] = key[6];
+        block[11] = key[7];
+        block[12] = (block_idx & 0xffff_ffff) as u32;
+        block[13] = ((block_idx >> 32) & 0xffff_ffff) as u32;
+        block[14] = iv[0];
+        block[15] = iv[1];
+    }
+
+    /// Add a block
+    #[inline]
+    fn add_block(&mut self) {
+        let iv = self.state.iv();
+        let key = self.state.key();
+        let block_idx = self.state.block_idx();
+        let block = self.state.block_mut();
+
+        block[0] = block[0].wrapping_add(0x6170_7865);
+        block[1] = block[1].wrapping_add(0x3320_646e);
+        block[2] = block[2].wrapping_add(0x7962_2d32);
+        block[3] = block[3].wrapping_add(0x6b20_6574);
+        block[4] = block[4].wrapping_add(key[0]);
+        block[5] = block[5].wrapping_add(key[1]);
+        block[6] = block[6].wrapping_add(key[2]);
+        block[7] = block[7].wrapping_add(key[3]);
+        block[8] = block[8].wrapping_add(key[4]);
+        block[9] = block[9].wrapping_add(key[5]);
+        block[10] = block[10].wrapping_add(key[6]);
+        block[11] = block[11].wrapping_add(key[7]);
+        block[12] = block[12].wrapping_add((block_idx & 0xffff_ffff) as u32);
+        block[13] = block[13].wrapping_add(((block_idx >> 32) & 0xffff_ffff) as u32);
+        block[14] = block[14].wrapping_add(iv[0]);
+        block[15] = block[15].wrapping_add(iv[1]);
+    }
+}
+
+impl SalsaFamilyCipher for Cipher {
+    #[inline]
+    fn next_block(&mut self) {
+        self.state.next_block();
+        self.gen_block();
+    }
+
+    #[inline]
+    fn offset(&self) -> usize {
+        self.state.offset()
+    }
+
+    #[inline]
+    fn set_offset(&mut self, offset: usize) {
+        self.state.set_offset(offset)
+    }
+
+    #[inline]
+    fn block_word(&self, idx: usize) -> u32 {
+        self.state.block_word(idx)
+    }
+}
+
+impl SyncStreamCipher for Cipher {
+    fn try_apply_keystream(&mut self, data: &mut [u8]) -> Result<(), LoopError> {
+        self.process(data);
+        Ok(())
+    }
+}
+
+impl SyncStreamCipherSeek for Cipher {
+    fn current_pos(&self) -> u64 {
+        self.state.current_pos()
+    }
+
+    fn seek(&mut self, pos: u64) {
+        self.state.seek(pos);
+        self.gen_block();
+    }
+}
+
+/// The ChaCha20 quarter round function
+#[inline]
+pub(crate) fn quarter_round(a: usize, b: usize, c: usize, d: usize, block: &mut [u32; 16]) {
+    block[a] = block[a].wrapping_add(block[b]);
+    block[d] ^= block[a];
+    block[d] = block[d].rotate_left(16);
+
+    block[c] = block[c].wrapping_add(block[d]);
+    block[b] ^= block[c];
+    block[b] = block[b].rotate_left(12);
+
+    block[a] = block[a].wrapping_add(block[b]);
+    block[d] ^= block[a];
+    block[d] = block[d].rotate_left(8);
+
+    block[c] = block[c].wrapping_add(block[d]);
+    block[b] ^= block[c];
+    block[b] = block[b].rotate_left(7);
+}

--- a/chacha20/src/legacy.rs
+++ b/chacha20/src/legacy.rs
@@ -1,0 +1,41 @@
+//! Legacy version of ChaCha20 with a 64-bit nonce
+
+use crate::cipher::Cipher;
+use block_cipher_trait::generic_array::typenum::{U32, U8};
+use block_cipher_trait::generic_array::GenericArray;
+use salsa20_core::SalsaFamilyState;
+use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
+
+/// The ChaCha20 stream cipher (legacy "djb" construction with 64-bit nonce).
+///
+/// The `legacy` Cargo feature must be enabled to use this.
+pub struct ChaCha20Legacy(Cipher);
+
+impl NewStreamCipher for ChaCha20Legacy {
+    /// Key size in bytes
+    type KeySize = U32;
+
+    /// Nonce size in bytes
+    type NonceSize = U8;
+
+    fn new(key: &GenericArray<u8, Self::KeySize>, iv: &GenericArray<u8, Self::NonceSize>) -> Self {
+        let cipher = Cipher::new(SalsaFamilyState::new(key, iv));
+        ChaCha20Legacy(cipher)
+    }
+}
+
+impl SyncStreamCipher for ChaCha20Legacy {
+    fn try_apply_keystream(&mut self, data: &mut [u8]) -> Result<(), LoopError> {
+        self.0.try_apply_keystream(data)
+    }
+}
+
+impl SyncStreamCipherSeek for ChaCha20Legacy {
+    fn current_pos(&self) -> u64 {
+        self.0.current_pos()
+    }
+
+    fn seek(&mut self, pos: u64) {
+        self.0.seek(pos);
+    }
+}

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -55,14 +55,20 @@ extern crate salsa20_core;
 #[cfg(feature = "xchacha20")]
 extern crate byteorder;
 
+pub(crate) mod cipher;
+#[cfg(feature = "legacy")]
+mod legacy;
 #[cfg(feature = "xchacha20")]
 mod xchacha20;
 
-use block_cipher_trait::generic_array::typenum::{U12, U32, U8};
-use block_cipher_trait::generic_array::{ArrayLength, GenericArray};
-use salsa20_core::{SalsaFamilyCipher, SalsaFamilyState};
+use self::cipher::Cipher;
+use block_cipher_trait::generic_array::typenum::{U12, U32};
+use block_cipher_trait::generic_array::GenericArray;
+use salsa20_core::SalsaFamilyState;
 use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
 
+#[cfg(feature = "legacy")]
+pub use self::legacy::ChaCha20Legacy;
 #[cfg(feature = "xchacha20")]
 pub use self::xchacha20::XChaCha20;
 
@@ -70,164 +76,9 @@ pub use self::xchacha20::XChaCha20;
 ///
 /// Use `ChaCha20Legacy` for the legacy (a.k.a. "djb") construction with a
 /// 64-bit nonce.
-pub struct ChaCha20(ChaChaState<U12>);
+pub struct ChaCha20(Cipher);
 
-/// The ChaCha20 stream cipher (legacy "djb" construction with 64-bit nonce).
-///
-/// The `legacy` Cargo feature must be enabled to use this.
-#[cfg(feature = "legacy")]
-pub struct ChaCha20Legacy(ChaChaState<U8>);
-
-macro_rules! impl_chacha20 {
-    ($type:path, $noncesize:ty) => {
-        impl NewStreamCipher for $type {
-            /// Key size in bytes
-            type KeySize = U32;
-
-            /// Nonce size in bytes
-            type NonceSize = $noncesize;
-
-            fn new(
-                key: &GenericArray<u8, Self::KeySize>,
-                iv: &GenericArray<u8, Self::NonceSize>,
-            ) -> Self {
-                let mut out = $type(ChaChaState::new(key, iv));
-                out.0.gen_block();
-                out
-            }
-        }
-
-        impl core::ops::Deref for $type {
-            type Target = ChaChaState<$noncesize>;
-
-            fn deref(&self) -> &Self::Target {
-                &self.0
-            }
-        }
-
-        impl core::ops::DerefMut for $type {
-            fn deref_mut(&mut self) -> &mut Self::Target {
-                &mut self.0
-            }
-        }
-    };
-}
-
-impl_chacha20!(ChaCha20, U12);
-
-#[cfg(feature = "legacy")]
-impl_chacha20!(ChaCha20Legacy, U8);
-
-/// Wrapper for state for ChaCha-type ciphers.
-#[derive(Debug)]
-pub struct ChaChaState<N: ArrayLength<u8>> {
-    state: SalsaFamilyState,
-    phantom: core::marker::PhantomData<N>,
-}
-
-impl<N: ArrayLength<u8>> ChaChaState<N> {
-    pub(crate) fn gen_block(&mut self) {
-        self.init_block();
-        self.rounds();
-        self.add_block();
-    }
-
-    #[inline]
-    fn rounds(&mut self) {
-        self.double_round();
-        self.double_round();
-        self.double_round();
-        self.double_round();
-        self.double_round();
-
-        self.double_round();
-        self.double_round();
-        self.double_round();
-        self.double_round();
-        self.double_round();
-    }
-
-    #[inline]
-    fn double_round(&mut self) {
-        let block = self.state.block_mut();
-
-        quarter_round(0, 4, 8, 12, block);
-        quarter_round(1, 5, 9, 13, block);
-        quarter_round(2, 6, 10, 14, block);
-        quarter_round(3, 7, 11, 15, block);
-        quarter_round(0, 5, 10, 15, block);
-        quarter_round(1, 6, 11, 12, block);
-        quarter_round(2, 7, 8, 13, block);
-        quarter_round(3, 4, 9, 14, block);
-    }
-
-    #[inline]
-    fn init_block(&mut self) {
-        let iv = self.state.iv();
-        let key = self.state.key();
-        let block_idx = self.state.block_idx();
-        let block = self.state.block_mut();
-
-        block[0] = 0x6170_7865;
-        block[1] = 0x3320_646e;
-        block[2] = 0x7962_2d32;
-        block[3] = 0x6b20_6574;
-        block[4] = key[0];
-        block[5] = key[1];
-        block[6] = key[2];
-        block[7] = key[3];
-        block[8] = key[4];
-        block[9] = key[5];
-        block[10] = key[6];
-        block[11] = key[7];
-        block[12] = (block_idx & 0xffff_ffff) as u32;
-        block[13] = ((block_idx >> 32) & 0xffff_ffff) as u32;
-        block[14] = iv[0];
-        block[15] = iv[1];
-    }
-
-    #[inline]
-    fn add_block(&mut self) {
-        let iv = self.state.iv();
-        let key = self.state.key();
-        let block_idx = self.state.block_idx();
-        let block = self.state.block_mut();
-
-        block[0] = block[0].wrapping_add(0x6170_7865);
-        block[1] = block[1].wrapping_add(0x3320_646e);
-        block[2] = block[2].wrapping_add(0x7962_2d32);
-        block[3] = block[3].wrapping_add(0x6b20_6574);
-        block[4] = block[4].wrapping_add(key[0]);
-        block[5] = block[5].wrapping_add(key[1]);
-        block[6] = block[6].wrapping_add(key[2]);
-        block[7] = block[7].wrapping_add(key[3]);
-        block[8] = block[8].wrapping_add(key[4]);
-        block[9] = block[9].wrapping_add(key[5]);
-        block[10] = block[10].wrapping_add(key[6]);
-        block[11] = block[11].wrapping_add(key[7]);
-        block[12] = block[12].wrapping_add((block_idx & 0xffff_ffff) as u32);
-        block[13] = block[13].wrapping_add(((block_idx >> 32) & 0xffff_ffff) as u32);
-        block[14] = block[14].wrapping_add(iv[0]);
-        block[15] = block[15].wrapping_add(iv[1]);
-    }
-}
-
-impl NewStreamCipher for ChaChaState<U8> {
-    /// Key size in bytes
-    type KeySize = U32;
-
-    /// Nonce size in bytes
-    type NonceSize = U8;
-
-    fn new(key: &GenericArray<u8, Self::KeySize>, iv: &GenericArray<u8, Self::NonceSize>) -> Self {
-        ChaChaState {
-            state: SalsaFamilyState::new(key, iv),
-            phantom: core::marker::PhantomData,
-        }
-    }
-}
-
-impl NewStreamCipher for ChaChaState<U12> {
+impl NewStreamCipher for ChaCha20 {
     /// Key size in bytes
     type KeySize = U32;
 
@@ -245,75 +96,22 @@ impl NewStreamCipher for ChaChaState<U12> {
         let state =
             SalsaFamilyState::new_with_idx(key, GenericArray::from_slice(base_iv), block_idx);
 
-        Self {
-            state,
-            phantom: core::marker::PhantomData,
-        }
+        ChaCha20(Cipher::new(state))
     }
 }
 
-impl<N: ArrayLength<u8>> SalsaFamilyCipher for ChaChaState<N> {
-    #[inline]
-    fn next_block(&mut self) {
-        self.state.next_block();
-        self.gen_block();
-    }
-
-    #[inline]
-    fn offset(&self) -> usize {
-        self.state.offset()
-    }
-
-    #[inline]
-    fn set_offset(&mut self, offset: usize) {
-        self.state.set_offset(offset)
-    }
-
-    #[inline]
-    fn block_word(&self, idx: usize) -> u32 {
-        self.state.block_word(idx)
-    }
-}
-
-impl<N> SyncStreamCipher for ChaChaState<N>
-where
-    N: ArrayLength<u8>,
-{
+impl SyncStreamCipher for ChaCha20 {
     fn try_apply_keystream(&mut self, data: &mut [u8]) -> Result<(), LoopError> {
-        self.process(data);
-        Ok(())
+        self.0.try_apply_keystream(data)
     }
 }
 
-impl<N> SyncStreamCipherSeek for ChaChaState<N>
-where
-    N: ArrayLength<u8>,
-{
+impl SyncStreamCipherSeek for ChaCha20 {
     fn current_pos(&self) -> u64 {
-        self.state.current_pos()
+        self.0.current_pos()
     }
 
     fn seek(&mut self, pos: u64) {
-        self.state.seek(pos);
-        self.gen_block();
+        self.0.seek(pos);
     }
-}
-
-#[inline]
-fn quarter_round(a: usize, b: usize, c: usize, d: usize, block: &mut [u32; 16]) {
-    block[a] = block[a].wrapping_add(block[b]);
-    block[d] ^= block[a];
-    block[d] = block[d].rotate_left(16);
-
-    block[c] = block[c].wrapping_add(block[d]);
-    block[b] ^= block[c];
-    block[b] = block[b].rotate_left(12);
-
-    block[a] = block[a].wrapping_add(block[b]);
-    block[d] ^= block[a];
-    block[d] = block[d].rotate_left(8);
-
-    block[c] = block[c].wrapping_add(block[d]);
-    block[b] ^= block[c];
-    block[b] = block[b].rotate_left(7);
 }

--- a/chacha20/src/xchacha20.rs
+++ b/chacha20/src/xchacha20.rs
@@ -12,7 +12,7 @@
 //!
 //! <https://tools.ietf.org/html/draft-arciszewski-xchacha-03>
 
-use super::{quarter_round, ChaCha20};
+use super::{ChaCha20, cipher::quarter_round};
 use block_cipher_trait::generic_array::typenum::{U16, U24, U32};
 use block_cipher_trait::generic_array::GenericArray;
 use byteorder::{ByteOrder, LE};


### PR DESCRIPTION
This commit primarily renames the previous `ChaChaState` type and factors it under `chacha20::cipher::Cipher`.

Additionally, it gets rid of a number of unnecessary things from the previous implementation:

- `ArrayLength` generic parameter
- `Deref`/`DerefMut` impls
- Macros to define them

Instead, `ChaCha20` and `ChaCha20Legacy` are now proper newtypes of `Cipher`, sharing a completely identical core cipher type, but also fully encapsulating it so it's no longer part of the public-facing API whatsoever.

To do that, each of `ChaCha20` and `ChaCha20Legacy` each impl `NewStreamCipher`, `SyncStreamCipher`, and `SyncStreamCipherSeek` directly. This is actually a good and important thing for `NewStreamCipher` in particular, since that is where the differences
between the two of them actually exist.

Overall I'd say this is a lot cleaner, and hides the `ChaChaState`/`Cipher` type from the public-facing API.