### PR TITLE
chacha20/salsa20/salsa20-core v0.2.0

### DIFF
--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Chacha20 Stream Cipher"
@@ -12,7 +12,7 @@ readme = "README.md"
 [dependencies]
 byteorder = { version = "1", default-features = false }
 stream-cipher = "0.3"
-salsa20-core = { version = "0.1", path = "../salsa20-core" }
+salsa20-core = { version = "0.2", path = "../salsa20-core" }
 
 [dev-dependencies]
 stream-cipher = { version = "0.3", features = ["dev"] }

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -11,7 +11,7 @@
 //! This crate contains three variants of ChaCha20:
 //!
 //! - `ChaCha20`: standard IETF variant with 96-bit nonce
-//! - `ChaCha20Legacy`: (gated under the `legacy` feature) "djb" variant iwth 64-bit nonce
+//! - `ChaCha20Legacy`: (gated under the `legacy` feature) "djb" variant with 64-bit nonce
 //! - `XChaCha20`: (gated under the `xchacha20` feature) 192-bit extended nonce variant
 //!
 //! # Security Warning

--- a/chacha20/src/xchacha20.rs
+++ b/chacha20/src/xchacha20.rs
@@ -1,16 +1,4 @@
-//! XChaCha20 is an adaptation of the XSalsa20 extended nonce construction
-//! described in the paper "Extending the Salsa20 Nonce", but using the
-//! 96-bit nonce variant of ChaCha20 rather than Salsa20 as the underlying
-//! cipher, deriving a shorter key/nonce from an extended nonce:
-//!
-//! <https://cr.yp.to/snuffle/xsalsa-20081128.pdf>
-//!
-//! No authoritative specification exists for XChaCha20, however the
-//! construction has "rough consensus and running code" in the form of
-//! several interoperable libraries and protocols (e.g. libsodium, WireGuard)
-//! and is documented in an (expired) IETF draft:
-//!
-//! <https://tools.ietf.org/html/draft-arciszewski-xchacha-03>
+//! XChaCha20 is an extended nonce variant of ChaCha20
 
 use super::ChaCha20;
 use block::quarter_round;
@@ -24,7 +12,24 @@ use stream_cipher::generic_array::{
 };
 use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
 
-/// XChaCha20 is an extended nonce variant of ChaCha20
+/// XChaCha20 is a ChaCha20 variant with an extended 192-bit (24-byte) nonce.
+///
+/// The construction is an adaptation of the same techniques used by
+/// XSalsa20 as described in the paper "Extending the Salsa20 Nonce",
+/// applied to the 96-bit nonce variant of ChaCha20, and derive a
+/// separate subkey/nonce for each extended nonce:
+///
+/// <https://cr.yp.to/snuffle/xsalsa-20081128.pdf>
+///
+/// No authoritative specification exists for XChaCha20, however the
+/// construction has "rough consensus and running code" in the form of
+/// several interoperable libraries and protocols (e.g. libsodium, WireGuard)
+/// and is documented in an (expired) IETF draft:
+///
+/// <https://tools.ietf.org/html/draft-arciszewski-xchacha-03>
+///
+/// The `xchacha20` Cargo feature must be enabled in order to use this
+/// (which it is by default).
 pub struct XChaCha20(ChaCha20);
 
 impl NewStreamCipher for XChaCha20 {

--- a/salsa20-core/Cargo.toml
+++ b/salsa20-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa20-core"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Eric McCorkle <eric@metricspace.net>"]
 license = "MIT OR Apache-2.0"
 description = "Salsa Family Stream Ciphers"

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa20"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Salsa20 Stream Cipher"
@@ -12,7 +12,7 @@ readme = "README.md"
 [dependencies]
 byteorder = { version = "1", default-features = false }
 stream-cipher = "0.3"
-salsa20-core = { version = "0.1", path = "../salsa20-core"}
+salsa20-core = { version = "0.2", path = "../salsa20-core"}
 
 [dev-dependencies]
 stream-cipher = { version = "0.3", features = ["dev"] }


### PR DESCRIPTION
v0.2.0 release of the Salsa20 family cipher crates.