### PR TITLE
salsa20-core: Don't implicitly depend on `zeroize/std`

### DIFF
--- a/salsa20-core/Cargo.toml
+++ b/salsa20-core/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 stream-cipher = "0.3"
-zeroize = { version = "0.9", optional = true }
+zeroize = { version = "0.9", optional = true, default-features = false }
 
 [dev-dependencies]
 stream-cipher = { version = "0.3", features = ["dev"] }


### PR DESCRIPTION
The `std` feature of `zeroize` was previously being activated.

This commit disables default features.