### PR TITLE
salsa20-core v0.2.1

### DIFF
--- a/salsa20-core/CHANGES.md
+++ b/salsa20-core/CHANGES.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.1 (2019-08-19)
+### Changed
+- Don't implicitly depend on `zeroize/std` ([#46])
+
+[#46]: https://github.com/RustCrypto/stream-ciphers/pull/46
+
+## 0.2.0 (2019-08-18)
+### Changed
+- Refactor around a `ctr`-like type ([#44])
+- Move all code into `lib.rs` ([#28])
+
+[#44]: https://github.com/RustCrypto/stream-ciphers/pull/44
+[#28]: https://github.com/RustCrypto/stream-ciphers/pull/28
+
+## 0.1.0 (2019-06-24)
+
+- Initial release

--- a/salsa20-core/Cargo.toml
+++ b/salsa20-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa20-core"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Eric McCorkle <eric@metricspace.net>"]
 license = "MIT OR Apache-2.0"
 description = "Salsa Family Stream Ciphers"


### PR DESCRIPTION
### Changed
- Don't implicitly depend on `zeroize/std` (#46)