### PR TITLE
Add XSalsa20

### DIFF
--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -18,7 +18,9 @@ salsa20-core = { version = "0.2", path = "../salsa20-core"}
 stream-cipher = { version = "0.3", features = ["dev"] }
 
 [features]
+default = ["xsalsa20"]
 zeroize = ["salsa20-core/zeroize"]
+xsalsa20 = []
 
 [badges]
 travis-ci = { repository = "RustCrypto/stream-ciphers" }

--- a/salsa20/src/block.rs
+++ b/salsa20/src/block.rs
@@ -64,79 +64,18 @@ impl Block {
     #[inline]
     fn double_round(&mut self) {
         let state = &mut self.state;
-        let mut t: u32;
 
-        t = state[0].wrapping_add(state[12]);
-        state[4] ^= t.rotate_left(7) as u32;
-        t = state[5].wrapping_add(state[1]);
-        state[9] ^= t.rotate_left(7) as u32;
-        t = state[10].wrapping_add(state[6]);
-        state[14] ^= t.rotate_left(7) as u32;
-        t = state[15].wrapping_add(state[11]);
-        state[3] ^= t.rotate_left(7) as u32;
+        // column rounds
+        quarter_round(0, 4, 8, 12, state);
+        quarter_round(5, 9, 13, 1, state);
+        quarter_round(10, 14, 2, 6, state);
+        quarter_round(15, 3, 7, 11, state);
 
-        t = state[4].wrapping_add(state[0]);
-        state[8] ^= t.rotate_left(9) as u32;
-        t = state[9].wrapping_add(state[5]);
-        state[13] ^= t.rotate_left(9) as u32;
-        t = state[14].wrapping_add(state[10]);
-        state[2] ^= t.rotate_left(9) as u32;
-        t = state[3].wrapping_add(state[15]);
-        state[7] ^= t.rotate_left(9) as u32;
-
-        t = state[8].wrapping_add(state[4]);
-        state[12] ^= t.rotate_left(13) as u32;
-        t = state[13].wrapping_add(state[9]);
-        state[1] ^= t.rotate_left(13) as u32;
-        t = state[2].wrapping_add(state[14]);
-        state[6] ^= t.rotate_left(13) as u32;
-        t = state[7].wrapping_add(state[3]);
-        state[11] ^= t.rotate_left(13) as u32;
-
-        t = state[12].wrapping_add(state[8]);
-        state[0] ^= t.rotate_left(18) as u32;
-        t = state[1].wrapping_add(state[13]);
-        state[5] ^= t.rotate_left(18) as u32;
-        t = state[6].wrapping_add(state[2]);
-        state[10] ^= t.rotate_left(18) as u32;
-        t = state[11].wrapping_add(state[7]);
-        state[15] ^= t.rotate_left(18) as u32;
-
-        t = state[0].wrapping_add(state[3]);
-        state[1] ^= t.rotate_left(7) as u32;
-        t = state[5].wrapping_add(state[4]);
-        state[6] ^= t.rotate_left(7) as u32;
-        t = state[10].wrapping_add(state[9]);
-        state[11] ^= t.rotate_left(7) as u32;
-        t = state[15].wrapping_add(state[14]);
-        state[12] ^= t.rotate_left(7) as u32;
-
-        t = state[1].wrapping_add(state[0]);
-        state[2] ^= t.rotate_left(9) as u32;
-        t = state[6].wrapping_add(state[5]);
-        state[7] ^= t.rotate_left(9) as u32;
-        t = state[11].wrapping_add(state[10]);
-        state[8] ^= t.rotate_left(9) as u32;
-        t = state[12].wrapping_add(state[15]);
-        state[13] ^= t.rotate_left(9) as u32;
-
-        t = state[2].wrapping_add(state[1]);
-        state[3] ^= t.rotate_left(13) as u32;
-        t = state[7].wrapping_add(state[6]);
-        state[4] ^= t.rotate_left(13) as u32;
-        t = state[8].wrapping_add(state[11]);
-        state[9] ^= t.rotate_left(13) as u32;
-        t = state[13].wrapping_add(state[12]);
-        state[14] ^= t.rotate_left(13) as u32;
-
-        t = state[3].wrapping_add(state[2]);
-        state[0] ^= t.rotate_left(18) as u32;
-        t = state[4].wrapping_add(state[7]);
-        state[5] ^= t.rotate_left(18) as u32;
-        t = state[9].wrapping_add(state[8]);
-        state[10] ^= t.rotate_left(18) as u32;
-        t = state[14].wrapping_add(state[13]);
-        state[15] ^= t.rotate_left(18) as u32;
+        // diagonal rounds
+        quarter_round(0, 1, 2, 3, state);
+        quarter_round(5, 6, 7, 4, state);
+        quarter_round(10, 11, 8, 9, state);
+        quarter_round(15, 12, 13, 14, state);
     }
 
     /// Finish computing a state
@@ -168,4 +107,21 @@ impl Block {
 
         state
     }
+}
+
+#[inline]
+pub(crate) fn quarter_round(a: usize, b: usize, c: usize, d: usize, state: &mut [u32; 16]) {
+    let mut t: u32;
+
+    t = state[a].wrapping_add(state[d]);
+    state[b] ^= t.rotate_left(7) as u32;
+
+    t = state[b].wrapping_add(state[a]);
+    state[c] ^= t.rotate_left(9) as u32;
+
+    t = state[c].wrapping_add(state[b]);
+    state[d] ^= t.rotate_left(13) as u32;
+
+    t = state[d].wrapping_add(state[c]);
+    state[a] ^= t.rotate_left(18) as u32;
 }

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -43,6 +43,8 @@ extern crate salsa20_core;
 
 mod block;
 mod cipher;
+#[cfg(feature = "xsalsa20")]
+mod xsalsa20;
 
 use cipher::Cipher;
 use stream_cipher::generic_array::typenum::{U32, U8};
@@ -50,6 +52,8 @@ use stream_cipher::generic_array::GenericArray;
 use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
 
 use salsa20_core::Ctr;
+#[cfg(feature = "xsalsa20")]
+pub use self::xsalsa20::XSalsa20;
 
 /// The Salsa20 cipher.
 #[derive(Debug)]

--- a/salsa20/src/xsalsa20.rs
+++ b/salsa20/src/xsalsa20.rs
@@ -1,0 +1,119 @@
+//! XSalsa20 is an extended nonce variant of Salsa20
+
+use super::Salsa20;
+use block::quarter_round;
+use byteorder::{ByteOrder, LE};
+#[cfg(feature = "zeroize")]
+use salsa20_core::zeroize::Zeroize;
+use salsa20_core::CONSTANTS;
+use stream_cipher::generic_array::{
+    typenum::{U16, U24, U32},
+    GenericArray,
+};
+use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
+
+/// XSalsa20 is a Salsa20 variant with an extended 192-bit (24-byte) nonce.
+///
+/// Based on the paper "Extending the Salsa20 Nonce":
+///
+/// <https://cr.yp.to/snuffle/xsalsa-20081128.pdf>
+///
+/// The `xsalsa20` Cargo feature must be enabled in order to use this
+/// (which it is by default).
+pub struct XSalsa20(Salsa20);
+
+impl NewStreamCipher for XSalsa20 {
+    /// Key size in bytes
+    type KeySize = U32;
+
+    /// Nonce size in bytes
+    type NonceSize = U24;
+
+    #[allow(unused_mut, clippy::let_and_return)]
+    fn new(key: &GenericArray<u8, Self::KeySize>, iv: &GenericArray<u8, Self::NonceSize>) -> Self {
+        let mut subkey = hsalsa20(key, iv[..16].as_ref().into());
+        let mut padded_iv = GenericArray::default();
+        padded_iv.copy_from_slice(&iv[16..]);
+
+        let mut result = XSalsa20(Salsa20::new(&subkey, &padded_iv));
+
+        #[cfg(feature = "zeroize")]
+        {
+            subkey.as_mut_slice().zeroize();
+        }
+
+        result
+    }
+}
+
+impl SyncStreamCipher for XSalsa20 {
+    fn try_apply_keystream(&mut self, data: &mut [u8]) -> Result<(), LoopError> {
+        self.0.try_apply_keystream(data)
+    }
+}
+
+impl SyncStreamCipherSeek for XSalsa20 {
+    fn current_pos(&self) -> u64 {
+        self.0.current_pos()
+    }
+
+    fn seek(&mut self, pos: u64) {
+        self.0.seek(pos);
+    }
+}
+
+/// HSalsa20 takes 512-bits of input:
+///
+/// * Constants (`u32` x 4)
+/// * Key (`u32` x 8)
+/// * Nonce (`u32` x 4)
+///
+/// It produces 256-bits of output suitable for use as a Salsa20 key
+///
+/// For more information on HSalsa20, see:
+///
+/// <http://cr.yp.to/snuffle/xsalsa-20110204.pdf>
+fn hsalsa20(key: &GenericArray<u8, U32>, input: &GenericArray<u8, U16>) -> GenericArray<u8, U32> {
+    let mut state = [0u32; 16];
+
+    state[0] = CONSTANTS[0];
+    state[5] = CONSTANTS[1];
+    state[10] = CONSTANTS[2];
+    state[15] = CONSTANTS[3];
+
+    for (i, chunk) in key.chunks(4).take(4).enumerate() {
+        state[1 + i] = LE::read_u32(chunk);
+    }
+
+    for (i, chunk) in key.chunks(4).skip(4).enumerate() {
+        state[11 + i] = LE::read_u32(chunk);
+    }
+
+    for (i, chunk) in input.chunks(4).enumerate() {
+        state[6 + i] = LE::read_u32(chunk);
+    }
+
+    // 20 rounds consisting of 10 column rounds and 10 diagonal rounds
+    for _ in 0..10 {
+        // column rounds
+        quarter_round(0, 4, 8, 12, &mut state);
+        quarter_round(5, 9, 13, 1, &mut state);
+        quarter_round(10, 14, 2, 6, &mut state);
+        quarter_round(15, 3, 7, 11, &mut state);
+
+        // diagonal rounds
+        quarter_round(0, 1, 2, 3, &mut state);
+        quarter_round(5, 6, 7, 4, &mut state);
+        quarter_round(10, 11, 8, 9, &mut state);
+        quarter_round(15, 12, 13, 14, &mut state);
+    }
+
+    let mut output = GenericArray::default();
+    let key_idx: [usize; 8] = [0, 5, 10, 15, 6, 7, 8, 9];
+
+    for (i, chunk) in output.chunks_mut(4).enumerate() {
+        LE::write_u32(chunk, state[key_idx[i]]);
+    }
+
+    output
+}


### PR DESCRIPTION
This PR adds XSalsa20 to the `salsa20` crate (addresses #53). The implementation is based on the XChaCha20 implementation in the `chacha20` crate. As in the `chacha20` crate, I have modified the `double_round` function in `salsa20/src/block.rs` so that it consists of multiple calls to a `quarter_round` function. This allows me to reuse `quarter_round` in the `hsalsa20` function.

I could not find test vectors for `hsalsa20`. However, I have I added test vectors for XSalsa20 to `salsa20/tests/lib.rs.` These test vectors were taken from the golang implementation of XSalsa20.