### PR TITLE
chacha20: Use criterion for benchmarking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,26 +25,34 @@ matrix:
       rust: 1.27.0
       env: {} # clear `-D warnings` above; allow warnings
       script:
-        - cargo test --all --release
+        - cargo test --all --exclude chacha20 --release
         - ./test_aesni.sh
+
+    # chacha20 crate with SSE2 backend
+    - name: "Rust: stable (chacha20)"
+      rust: stable
+      env: RUSTFLAGS="-Ctarget-feature=+sse2"
+      script: cargo test --package chacha20 --release
+
+    # no_std build
+    - name: "Rust: 1.27.0 (thumbv7em-none-eabihf)"
+      rust: 1.27.0
+      env: {} # clear `-D warnings` above; allow warnings
+      install: rustup target add thumbv7em-none-eabihf
+      script: cargo build --all --target thumbv7em-none-eabihf --release
     - name: "Rust: stable (thumbv7em-none-eabihf)"
       rust: stable
-      install:
-        - rustup target add thumbv7em-none-eabihf
-      script:
-        - cargo build --all --target thumbv7em-none-eabihf --release
+      install: rustup target add thumbv7em-none-eabihf
+      script: cargo build --all --target thumbv7em-none-eabihf --release
+
     - name: rustfmt
       rust: stable
-      install:
-        - rustup component add rustfmt
-      script:
-        - cargo fmt --all -- --check
+      install: rustup component add rustfmt
+      script: cargo fmt --all -- --check
     - name: clippy
       rust: stable
-      install:
-        - rustup component add clippy
-      script:
-        - cargo clippy --all
+      install: rustup component add clippy
+      script: cargo clippy --all
 
 branches:
   only:

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["crypto", "stream-cipher", "xchacha20"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
 
+[badges]
+travis-ci = { repository = "RustCrypto/stream-ciphers" }
+
 [dependencies]
 byteorder = { version = "1", default-features = false }
 stream-cipher = "0.3"
@@ -19,15 +22,18 @@ salsa20-core = { version = "0.2", path = "../salsa20-core" }
 
 [dev-dependencies]
 stream-cipher = { version = "0.3", features = ["dev"] }
-
-[badges]
-travis-ci = { repository = "RustCrypto/stream-ciphers" }
+criterion = "0.3"
+criterion-cycles-per-byte = "0.1"
 
 [features]
 default = ["xchacha20"]
 legacy = []
 xchacha20 = []
 zeroize = ["salsa20-core/zeroize"]
+
+[[bench]]
+name = "chacha20"
+harness = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/test_aesni.sh
+++ b/test_aesni.sh
@@ -1,1 +1,1 @@
-RUSTFLAGS="-C target-feature=+aes,+sse2,+ssse3" RUSTDOCFLAGS=$RUSTFLAGS cargo test --all
+RUSTFLAGS="-C target-feature=+aes,+sse2,+ssse3" RUSTDOCFLAGS=$RUSTFLAGS cargo test --all --exclude chacha20


### PR DESCRIPTION
...with the `criterion-cycles-per-byte` plugin

This unfortunately means we can no-longer run tests for chacha20 against Rust 1.27.0, since it adds 2018 edition `dev-dependencies`. However, we can still confirm release builds against this version work.

As we're starting to reach a microoptimization stage, I think criterion will be extremely helpful in determining if our microoptimizations are actually improving performance.

Currently I'm getting between 5.1 - 5.8 cpb across the tests on a Kaby Lake i7. Curiously `-Ctarget-cpu=native` seems to negatively impact performance. I'm not seeing much difference between the software and SSE2 backends: +5% on the `chacha20/apply_keystream/1024` benchmark, negligible on the others (i.e. +1-2%)