### PR TITLE
chacha20 v0.2.2

### DIFF
--- a/chacha20/CHANGES.md
+++ b/chacha20/CHANGES.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.2 (2019-10-22)
+### Added
+- SSE2 accelerated implementation ([#61])
+
+[#61]: https://github.com/RustCrypto/stream-ciphers/pull/61
+
 ## 0.2.1 (2019-08-19)
 ### Added
 - Add `MAX_BLOCKS` and `BLOCK_SIZE` constants ([#47])

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "chacha20"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["RustCrypto Developers"]
-license = "MIT OR Apache-2.0"
+license = "Apache-2.0 OR MIT"
 description = """
 The ChaCha20 stream cipher (RFC 8439) implemented using traits from the
 RustCrypto stream-cipher crate.

--- a/chacha20/src/block/mod.rs
+++ b/chacha20/src/block/mod.rs
@@ -1,6 +1,6 @@
-//! The ChaCha20 block function. Defined in RFC 7539 Section 2.3.
+//! The ChaCha20 block function. Defined in RFC 8439 Section 2.3.
 //!
-//! <https://tools.ietf.org/html/rfc7539#section-2.3>
+//! <https://tools.ietf.org/html/rfc8439#section-2.3>
 
 use salsa20_core::{CONSTANTS, IV_WORDS, KEY_WORDS, STATE_WORDS};
 

--- a/chacha20/src/cipher.rs
+++ b/chacha20/src/cipher.rs
@@ -13,7 +13,7 @@ pub(crate) struct Cipher {
     iv: [u32; IV_WORDS],
 
     /// Offset of the initial counter in the keystream. This is derived from
-    /// the extra 4 bytes in the 96-byte nonce RFC 7539 version (or is always
+    /// the extra 4 bytes in the 96-byte nonce RFC 8439 version (or is always
     /// 0 in the legacy version)
     counter_offset: u64,
 }

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -1,4 +1,4 @@
-//! The ChaCha20 stream cipher ([RFC 7539])
+//! The ChaCha20 stream cipher ([RFC 8439])
 //!
 //! ChaCha20 is a lightweight stream cipher which is amenable to fast,
 //! constant-time implementations in software. It improves upon the previous
@@ -46,7 +46,7 @@
 //! assert_eq!(data, [1, 2, 3, 4, 5, 6, 7]);
 //! ```
 //!
-//! [RFC 7539]: https://tools.ietf.org/html/rfc7539
+//! [RFC 8439]: https://tools.ietf.org/html/rfc8439
 //! [Salsa20]: https://docs.rs/salsa20
 
 #![no_std]
@@ -88,7 +88,7 @@ pub const MAX_BLOCKS: usize = core::u32::MAX as usize;
 /// Size of a ChaCha20 block in bytes
 pub const BLOCK_SIZE: usize = 64;
 
-/// The ChaCha20 stream cipher (RFC 7539 version with 96-bit nonce)
+/// The ChaCha20 stream cipher (RFC 8439 version with 96-bit nonce)
 ///
 /// Use `ChaCha20Legacy` for the legacy (a.k.a. "djb") construction with a
 /// 64-bit nonce.


### PR DESCRIPTION
### Added
- SSE2 accelerated implementation ([#61])

[#61]: https://github.com/RustCrypto/stream-ciphers/pull/61