### PR TITLE
hc-256/salsa20-core: Upgrade to zeroize v1.0

### DIFF
--- a/hc-256/Cargo.toml
+++ b/hc-256/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 block-cipher-trait = "0.6"
 stream-cipher = "0.3"
-zeroize = { version = "1.0.0-pre", optional = true }
+zeroize = { version = "1", optional = true }
 
 [dev-dependencies]
 stream-cipher = { version = "0.3", features = ["dev"] }

--- a/salsa20-core/Cargo.toml
+++ b/salsa20-core/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 stream-cipher = "0.3"
-zeroize = { version = "1.0.0-pre", optional = true, default-features = false }
+zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 stream-cipher = { version = "0.3", features = ["dev"] }


### PR DESCRIPTION
Release notes: https://github.com/iqlusioninc/crates/pull/279