### PR TITLE
salsa20-core v0.2.3

### DIFF
--- a/salsa20-core/CHANGES.md
+++ b/salsa20-core/CHANGES.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.3 (2019-10-22)
+## Changed
+- Upgrade to `zeroize` 1.0 final release ([#66])
+
+[#66]: https://github.com/RustCrypto/stream-ciphers/pull/66
+
 ## 0.2.2 (2019-10-01)
 ## Changed
-- Upgrade to zeroize 1.0.0-pre ([#55])
+- Upgrade to `zeroize` 1.0.0-pre ([#55])
 
 [#55]: https://github.com/RustCrypto/stream-ciphers/pull/55
 

--- a/salsa20-core/Cargo.toml
+++ b/salsa20-core/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "salsa20-core"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Eric McCorkle <eric@metricspace.net>"]
-license = "MIT OR Apache-2.0"
-description = "Salsa Family Stream Ciphers"
+license = "Apache-2.0 OR MIT"
+description = """
+Generic implementation of the stream-cipher crate traits for ciphers in the
+Salsa20 family. Used by the chacha20 and salsa20 crates.
+"""
 repository = "https://github.com/RustCrypto/stream-ciphers"
 keywords = ["crypto", "stream-cipher", "trait"]
 categories = ["cryptography", "no-std"]


### PR DESCRIPTION
## Changed
- Upgrade to `zeroize` 1.0 final release ([#66])

[#66]: https://github.com/RustCrypto/stream-ciphers/pull/66