### PR TITLE
ctr: Replace deprecated `mem::uninitialized` with `mem::zeroed`

### DIFF
--- a/ctr/src/lib.rs
+++ b/ctr/src/lib.rs
@@ -233,7 +233,7 @@ where
     fn generate_par_blocks(&self, counter: u64) -> Blocks<C> {
         let mut block = self.nonce;
         block[1] = block[1].wrapping_add(counter);
-        let mut blocks: Blocks<C> = unsafe { mem::uninitialized() };
+        let mut blocks: Blocks<C> = unsafe { mem::zeroed() };
         for b in blocks.iter_mut() {
             let block_be = conv_be(block);
             *b = unsafe { mem::transmute_copy(&block_be) };


### PR DESCRIPTION
The deprecation warnings on `mem::uninitialized` are breaking CI.

`mem::uninitialized` and `mem::zeroed` have  equivalent performance characteristics for the case where memory is always written to first, so this change should otherwise have no impact on performance.