### PR TITLE
chacha20: make 2018 edition crate; minor refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,9 @@ matrix:
     - rust: nightly
   fast_finish: true
   include:
-    - name: "Rust: 1.27.0"
-      rust: 1.27.0
-      env: {} # clear `-D warnings` above; allow warnings
-      script:
-        - cargo test --all --exclude chacha20 --release
-        - ./test_aesni.sh
+    - name: "Rust: 1.32.0"
+      rust: 1.32.0
+      script: ./test_aesni.sh
 
     # chacha20 crate with SSE2 backend
     - name: "Rust: stable (chacha20)"
@@ -35,9 +32,8 @@ matrix:
       script: cargo test --package chacha20 --release
 
     # no_std build
-    - name: "Rust: 1.27.0 (thumbv7em-none-eabihf)"
-      rust: 1.27.0
-      env: {} # clear `-D warnings` above; allow warnings
+    - name: "Rust: 1.32.0 (thumbv7em-none-eabihf)"
+      rust: 1.32.0
       install: rustup target add thumbv7em-none-eabihf
       script: cargo build --all --target thumbv7em-none-eabihf --release
     - name: "Rust: stable (thumbv7em-none-eabihf)"

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -11,15 +11,16 @@ repository = "https://github.com/RustCrypto/stream-ciphers"
 keywords = ["crypto", "stream-cipher", "xchacha20"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "RustCrypto/stream-ciphers" }
 
 [dependencies]
 byteorder = { version = "1", default-features = false }
-stream-cipher = "0.3"
-salsa20-core = { version = "0.2", path = "../salsa20-core" }
 rand_core = { version = "0.5", optional = true }
+salsa20-core = { version = "0.2", path = "../salsa20-core" }
+stream-cipher = "0.3"
 
 [dev-dependencies]
 stream-cipher = { version = "0.3", features = ["dev"] }

--- a/chacha20/benches/chacha20.rs
+++ b/chacha20/benches/chacha20.rs
@@ -1,11 +1,10 @@
-extern crate chacha20;
-extern crate criterion;
-extern crate criterion_cycles_per_byte;
-
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use criterion_cycles_per_byte::CyclesPerByte;
 
-use chacha20::{ChaCha20, stream_cipher::{NewStreamCipher, SyncStreamCipher}};
+use chacha20::{
+    stream_cipher::{NewStreamCipher, SyncStreamCipher},
+    ChaCha20,
+};
 
 const KB: usize = 1024;
 

--- a/chacha20/src/block.rs
+++ b/chacha20/src/block.rs
@@ -1,0 +1,56 @@
+//! The ChaCha20 block function. Defined in RFC 8439 Section 2.3.
+//!
+//! <https://tools.ietf.org/html/rfc8439#section-2.3>
+
+#[cfg(not(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "sse2"
+)))]
+pub(crate) mod soft;
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "sse2"
+))]
+mod sse2;
+
+#[cfg(not(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "sse2"
+)))]
+pub(crate) use self::soft::Block;
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "sse2"
+))]
+pub(crate) use self::sse2::Block;
+
+use salsa20_core::STATE_WORDS;
+
+/// The ChaCha20 quarter round function
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn quarter_round(
+    a: usize,
+    b: usize,
+    c: usize,
+    d: usize,
+    state: &mut [u32; STATE_WORDS],
+) {
+    state[a] = state[a].wrapping_add(state[b]);
+    state[d] ^= state[a];
+    state[d] = state[d].rotate_left(16);
+
+    state[c] = state[c].wrapping_add(state[d]);
+    state[b] ^= state[c];
+    state[b] = state[b].rotate_left(12);
+
+    state[a] = state[a].wrapping_add(state[b]);
+    state[d] ^= state[a];
+    state[d] = state[d].rotate_left(8);
+
+    state[c] = state[c].wrapping_add(state[d]);
+    state[b] ^= state[c];
+    state[b] = state[b].rotate_left(7);
+}

--- a/chacha20/src/cipher.rs
+++ b/chacha20/src/cipher.rs
@@ -1,8 +1,9 @@
 //! ChaCha20 cipher core implementation
 
+use super::MAX_BLOCKS;
+use crate::block::Block;
 use byteorder::{ByteOrder, LE};
 use salsa20_core::{SalsaFamilyCipher, IV_WORDS, KEY_WORDS, STATE_WORDS};
-use super::MAX_BLOCKS;
 
 /// ChaCha20 core cipher functionality
 #[derive(Clone, Debug)]
@@ -42,29 +43,9 @@ impl Cipher {
 
 impl SalsaFamilyCipher for Cipher {
     #[inline]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn block(&self, counter: u64) -> [u32; STATE_WORDS] {
         // TODO(tarcieri): avoid panic by making block API fallible
         assert!(counter < MAX_BLOCKS as u64, "MAX_BLOCKS exceeded");
-
-        if cfg!(target_feature = "sse2") {
-            unsafe {
-                super::block::sse2::Block::generate(
-                    &self.key,
-                    self.iv,
-                    self.counter_offset + counter,
-                )
-            }
-        } else {
-            super::block::Block::generate(&self.key, self.iv, self.counter_offset + counter)
-        }
-    }
-
-    #[inline]
-    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-    fn block(&self, counter: u64) -> [u32; STATE_WORDS] {
-        // TODO(tarcieri): avoid panic by making block API fallible
-        assert!(counter < MAX_BLOCKS as u64, "MAX_BLOCKS exceeded");
-        super::block::Block::generate(&self.key, self.iv, self.counter_offset + counter)
+        Block::generate(&self.key, self.iv, self.counter_offset + counter)
     }
 }

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -53,15 +53,7 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![deny(missing_docs)]
 
-pub extern crate stream_cipher;
-
-extern crate salsa20_core;
-
-// TODO: replace with `u32::from_le_bytes`/`to_le_bytes` in libcore (1.32+)
-#[cfg(feature = "xchacha20")]
-extern crate byteorder;
-#[cfg(feature = "rand_core")]
-extern crate rand_core;
+pub use stream_cipher;
 
 mod block;
 pub(crate) mod cipher;

--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -1,7 +1,7 @@
 //! Block RNG based on rand_core::BlockRng
 
-use rand_core::{RngCore, SeedableRng, Error};
 use rand_core::block::{BlockRng, BlockRngCore};
+use rand_core::{Error, RngCore, SeedableRng};
 use salsa20_core::{SalsaFamilyCipher, IV_BYTES, KEY_BYTES, STATE_WORDS};
 
 use crate::cipher::Cipher;
@@ -38,7 +38,6 @@ impl RngCore for ChaCha20Rng {
     }
 }
 
-
 /// Core of the [`ChaCha20Rng`] random number generator, for use with
 /// [`rand_core::block::BlockRng`].
 #[derive(Clone, Debug)]
@@ -53,10 +52,7 @@ impl SeedableRng for ChaCha20RngCore {
     fn from_seed(seed: Self::Seed) -> Self {
         let iv = [0; IV_BYTES];
         let cipher = Cipher::new(&seed, &iv, 0);
-        Self {
-            cipher,
-            counter: 0,
-        }
+        Self { cipher, counter: 0 }
     }
 }
 

--- a/chacha20/src/xchacha20.rs
+++ b/chacha20/src/xchacha20.rs
@@ -1,7 +1,7 @@
 //! XChaCha20 is an extended nonce variant of ChaCha20
 
 use super::ChaCha20;
-use block::quarter_round;
+use crate::block::quarter_round;
 use byteorder::{ByteOrder, LE};
 #[cfg(feature = "zeroize")]
 use salsa20_core::zeroize::Zeroize;

--- a/chacha20/tests/lib.rs
+++ b/chacha20/tests/lib.rs
@@ -1,6 +1,5 @@
 //! Tests for ChaCha20 (IETF and "djb" versions) as well as XChaCha20
 
-extern crate chacha20;
 #[macro_use]
 extern crate stream_cipher;
 


### PR DESCRIPTION
- Upgrades the `chacha20` crate to Rust 2018 edition
- Refactors the SSE2 backend to sit side-by-side w\ pure software one