### PR TITLE
clippy fixups; salsa20 refactor

### DIFF
--- a/chacha20/src/block/soft.rs
+++ b/chacha20/src/block/soft.rs
@@ -56,18 +56,21 @@ impl Block {
         let mut state = self.state;
 
         for _ in 0..(count / 2) {
+            // column rounds
             quarter_round(0, 4, 8, 12, &mut state);
             quarter_round(1, 5, 9, 13, &mut state);
             quarter_round(2, 6, 10, 14, &mut state);
             quarter_round(3, 7, 11, 15, &mut state);
+
+            // diagonal rounds
             quarter_round(0, 5, 10, 15, &mut state);
             quarter_round(1, 6, 11, 12, &mut state);
             quarter_round(2, 7, 8, 13, &mut state);
             quarter_round(3, 4, 9, 14, &mut state);
         }
 
-        for i in 0..16 {
-            state[i] = state[i].wrapping_add(self.state[i]);
+        for (s1, s0) in state.iter_mut().zip(&self.state) {
+            *s1 = s1.wrapping_add(*s0);
         }
 
         state

--- a/ctr/src/lib.rs
+++ b/ctr/src/lib.rs
@@ -37,8 +37,11 @@
 //! assert_eq!(data, [1, 2, 3, 4, 5, 6, 7]);
 //! # }
 //! ```
+
 #![no_std]
+#![allow(clippy::needless_doctest_main)]
 #![deny(missing_docs)]
+
 extern crate block_cipher_trait;
 pub extern crate stream_cipher;
 

--- a/hc-256/src/lib.rs
+++ b/hc-256/src/lib.rs
@@ -84,13 +84,8 @@ impl HC256 {
                 .wrapping_add(i as u32);
         }
 
-        for i in 0..TABLE_SIZE {
-            self.ptable[i] = data[i + 512];
-        }
-
-        for i in 0..TABLE_SIZE {
-            self.qtable[i] = data[i + 1536];
-        }
+        self.ptable[..TABLE_SIZE].clone_from_slice(&data[512..(TABLE_SIZE + 512)]);
+        self.qtable[..TABLE_SIZE].clone_from_slice(&data[1536..(TABLE_SIZE + 1536)]);
 
         self.idx = 0;
 
@@ -170,7 +165,7 @@ impl HC256 {
 
         // First, use the remaining part of the current word.
         for j in self.offset..4 {
-            data[i] = data[i] ^ ((word >> (j * 8)) & 0xff) as u8;
+            data[i] ^= ((word >> (j * 8)) & 0xff) as u8;
             i += 1;
         }
 
@@ -182,7 +177,7 @@ impl HC256 {
             word = self.gen_word();
 
             for j in 0..4 {
-                data[i] = data[i] ^ ((word >> (j * 8)) & 0xff) as u8;
+                data[i] ^= ((word >> (j * 8)) & 0xff) as u8;
                 i += 1;
             }
         }
@@ -192,7 +187,7 @@ impl HC256 {
             word = self.gen_word();
 
             for j in 0..leftover {
-                data[i] = data[i] ^ ((word >> (j * 8)) & 0xff) as u8;
+                data[i] ^= ((word >> (j * 8)) & 0xff) as u8;
                 i += 1;
             }
 


### PR DESCRIPTION
- Fixes all existing clippy warnings
- Applies same refactoring from #75 to the `salsa20` crate