### PR TITLE
chacha20: remove `byteorder` dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ matrix:
       script: cargo test --package chacha20 --release
 
     # no_std build
-    - name: "Rust: 1.32.0 (thumbv7em-none-eabihf)"
-      rust: 1.32.0
+    - name: "Rust: 1.34.0 (thumbv7em-none-eabihf)"
+      rust: 1.34.0
       install: rustup target add thumbv7em-none-eabihf
       script: cargo build --all --target thumbv7em-none-eabihf --release
     - name: "Rust: stable (thumbv7em-none-eabihf)"

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -17,7 +17,6 @@ edition = "2018"
 travis-ci = { repository = "RustCrypto/stream-ciphers" }
 
 [dependencies]
-byteorder = { version = "1", default-features = false }
 rand_core = { version = "0.5", optional = true }
 salsa20-core = { version = "0.2", path = "../salsa20-core" }
 stream-cipher = "0.3"

--- a/chacha20/README.md
+++ b/chacha20/README.md
@@ -53,7 +53,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/chacha20/badge.svg
 [docs-link]: https://docs.rs/chacha20/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.27+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.34+-blue.svg
 [build-image]: https://travis-ci.org/RustCrypto/stream-ciphers.svg?branch=master
 [build-link]: https://travis-ci.org/RustCrypto/stream-ciphers
 

--- a/chacha20/src/cipher.rs
+++ b/chacha20/src/cipher.rs
@@ -1,8 +1,7 @@
 //! ChaCha20 cipher core implementation
 
-use super::MAX_BLOCKS;
-use crate::block::Block;
-use byteorder::{ByteOrder, LE};
+use crate::{block::Block, MAX_BLOCKS};
+use core::convert::TryInto;
 use salsa20_core::{SalsaFamilyCipher, IV_WORDS, KEY_WORDS, STATE_WORDS};
 
 /// ChaCha20 core cipher functionality
@@ -25,12 +24,12 @@ impl Cipher {
     pub fn new(key_bytes: &[u8], iv_bytes: &[u8], counter_offset: u64) -> Self {
         let mut key = [0u32; KEY_WORDS];
         for (i, chunk) in key_bytes.chunks(4).enumerate() {
-            key[i] = LE::read_u32(chunk);
+            key[i] = u32::from_le_bytes(chunk.try_into().unwrap());
         }
 
         let mut iv = [0u32; IV_WORDS];
         for (i, chunk) in iv_bytes.chunks(4).enumerate() {
-            iv[i] = LE::read_u32(chunk);
+            iv[i] = u32::from_le_bytes(chunk.try_into().unwrap());
         }
 
         Cipher {


### PR DESCRIPTION
Uses the `core` endianess conversions instead