### PR TITLE
chacha20: Add ChaCha8 and ChaCha20 reduced round variants

### DIFF
--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -6,69 +6,93 @@ use rand_core::{Error, RngCore, SeedableRng};
 
 use crate::{block::Block, BLOCK_SIZE, KEY_SIZE, STATE_WORDS};
 
-/// Random number generator over the ChaCha20 stream cipher.
-#[derive(Clone, Debug)]
-pub struct ChaCha20Rng(BlockRng<ChaCha20RngCore>);
+macro_rules! impl_chacha_rng {
+    ($name:ident, $core:ident, $rounds:expr, $doc:expr) => {
+        #[doc = $doc]
+        #[derive(Clone, Debug)]
+        pub struct $name(BlockRng<$core>);
 
-impl SeedableRng for ChaCha20Rng {
-    type Seed = [u8; KEY_SIZE];
+        impl SeedableRng for $name {
+            type Seed = [u8; KEY_SIZE];
 
-    #[inline]
-    fn from_seed(seed: Self::Seed) -> Self {
-        let core = ChaCha20RngCore::from_seed(seed);
-        Self(BlockRng::new(core))
+            #[inline]
+            fn from_seed(seed: Self::Seed) -> Self {
+                let core = $core::from_seed(seed);
+                Self(BlockRng::new(core))
+            }
+        }
+
+        impl RngCore for $name {
+            #[inline]
+            fn next_u32(&mut self) -> u32 {
+                self.0.next_u32()
+            }
+
+            #[inline]
+            fn next_u64(&mut self) -> u64 {
+                self.0.next_u64()
+            }
+
+            #[inline]
+            fn fill_bytes(&mut self, bytes: &mut [u8]) {
+                self.0.fill_bytes(bytes)
+            }
+
+            #[inline]
+            fn try_fill_bytes(&mut self, bytes: &mut [u8]) -> Result<(), Error> {
+                self.0.try_fill_bytes(bytes)
+            }
+        }
+
+        #[doc = "Core random number generator, for use with [`rand_core::block::BlockRng`]"]
+        #[derive(Clone, Debug)]
+        pub struct $core {
+            block: Block,
+            counter: u64,
+        }
+
+        impl SeedableRng for $core {
+            type Seed = [u8; KEY_SIZE];
+
+            #[inline]
+            fn from_seed(seed: Self::Seed) -> Self {
+                let block = Block::new(&seed, Default::default(), $rounds);
+                Self { block, counter: 0 }
+            }
+        }
+
+        impl BlockRngCore for $core {
+            type Item = u32;
+            type Results = [u32; STATE_WORDS];
+
+            fn generate(&mut self, results: &mut Self::Results) {
+                // TODO(tarcieri): eliminate unsafety (replace w\ [u8; BLOCK_SIZE)
+                self.block.generate(self.counter, unsafe {
+                    slice::from_raw_parts_mut(results.as_mut_ptr() as *mut u8, BLOCK_SIZE)
+                });
+                self.counter += 1;
+            }
+        }
     }
 }
 
-impl RngCore for ChaCha20Rng {
-    #[inline]
-    fn next_u32(&mut self) -> u32 {
-        self.0.next_u32()
-    }
+impl_chacha_rng!(
+    ChaCha8Rng,
+    ChaCha8RngCore,
+    8,
+    "Random number generator over the ChaCha8 stream cipher."
+);
 
-    #[inline]
-    fn next_u64(&mut self) -> u64 {
-        self.0.next_u64()
-    }
+impl_chacha_rng!(
+    ChaCha12Rng,
+    ChaCha12RngCore,
+    12,
+    "Random number generator over the ChaCha12 stream cipher."
+);
 
-    #[inline]
-    fn fill_bytes(&mut self, bytes: &mut [u8]) {
-        self.0.fill_bytes(bytes)
-    }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, bytes: &mut [u8]) -> Result<(), Error> {
-        self.0.try_fill_bytes(bytes)
-    }
-}
-
-/// Core of the [`ChaCha20Rng`] random number generator, for use with
-/// [`rand_core::block::BlockRng`].
-#[derive(Clone, Debug)]
-pub struct ChaCha20RngCore {
-    block: Block,
-    counter: u64,
-}
-
-impl SeedableRng for ChaCha20RngCore {
-    type Seed = [u8; KEY_SIZE];
-
-    #[inline]
-    fn from_seed(seed: Self::Seed) -> Self {
-        let block = Block::new(&seed, Default::default(), 20);
-        Self { block, counter: 0 }
-    }
-}
-
-impl BlockRngCore for ChaCha20RngCore {
-    type Item = u32;
-    type Results = [u32; STATE_WORDS];
-
-    fn generate(&mut self, results: &mut Self::Results) {
-        // TODO(tarcieri): eliminate unsafety (replace w\ [u8; BLOCK_SIZE)
-        self.block.generate(self.counter, unsafe {
-            slice::from_raw_parts_mut(results.as_mut_ptr() as *mut u8, BLOCK_SIZE)
-        });
-        self.counter += 1;
-    }
-}
+impl_chacha_rng!(
+    ChaCha20Rng,
+    ChaCha20RngCore,
+    20,
+    "Random number generator over the ChaCha20 stream cipher."
+);


### PR DESCRIPTION
See the writeup I've already done for the `rand_chacha` crate for the rationale of including these by default:

https://github.com/rust-random/rand/issues/932

tl;dr: the "Too Much Crypto" paper goes into why ChaCha20 is overkill, ChaCha12 is probably what should've been standardized per the eSTREAM analysis of Salsa20 (but wasn't for cargo cult reasons), and ChaCha8 is still (probably) safe:

https://eprint.iacr.org/2019/1492