### PR TITLE
chacha20: Buffering bugfixes and AVX2 backend refactoring

### DIFF
--- a/chacha20/src/block/avx2.rs
+++ b/chacha20/src/block/avx2.rs
@@ -18,9 +18,9 @@ use core::arch::x86_64::*;
 
 #[derive(Clone)]
 pub(crate) struct Block {
-    d0: __m256i,
-    d1: __m256i,
-    d2: __m256i,
+    v0: __m256i,
+    v1: __m256i,
+    v2: __m256i,
     iv: [i32; 2],
     rounds: usize,
 }
@@ -41,9 +41,9 @@ impl Block {
         ];
 
         Self {
-            d0: v0,
-            d1: v1,
-            d2: v2,
+            v0,
+            v1,
+            v2,
             iv,
             rounds,
         }
@@ -52,15 +52,48 @@ impl Block {
     #[inline]
     pub(crate) fn generate(&self, counter: u64, output: &mut [u8]) {
         unsafe {
-            rounds(
-                self.rounds,
-                self.d0,
-                self.d1,
-                self.d2,
-                iv_setup(self.iv, counter),
-                output,
-            )
+            let (mut v0, mut v1, mut v2) = (self.v0, self.v1, self.v2);
+            let mut v3 = iv_setup(self.iv, counter);
+            self.rounds(&mut v0, &mut v1, &mut v2, &mut v3);
+            store(v0, v1, v2, v3, output);
         }
+    }
+
+    #[inline]
+    #[allow(clippy::cast_ptr_alignment)] // loadu/storeu support unaligned loads/stores
+    pub(crate) fn apply_keystream(&self, counter: u64, output: &mut [u8]) {
+        unsafe {
+            let (mut v0, mut v1, mut v2) = (self.v0, self.v1, self.v2);
+            let mut v3 = iv_setup(self.iv, counter);
+            self.rounds(&mut v0, &mut v1, &mut v2, &mut v3);
+
+            for (chunk, a) in output.chunks_mut(0x10).zip(&[v0, v1, v2, v3]) {
+                let b = _mm_loadu_si128(chunk.as_ptr() as *const __m128i);
+                let out = _mm_xor_si128(_mm256_castsi256_si128(*a), b);
+                _mm_storeu_si128(chunk.as_mut_ptr() as *mut __m128i, out);
+            }
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    unsafe fn rounds(
+        &self,
+        v0: &mut __m256i,
+        v1: &mut __m256i,
+        v2: &mut __m256i,
+        v3: &mut __m256i,
+    ) {
+        let v3_orig = *v3;
+
+        for _ in 0..(self.rounds / 2) {
+            double_quarter_round(v0, v1, v2, v3);
+        }
+
+        *v0 = _mm256_add_epi32(*v0, self.v0);
+        *v1 = _mm256_add_epi32(*v1, self.v1);
+        *v2 = _mm256_add_epi32(*v2, self.v2);
+        *v3 = _mm256_add_epi32(*v3, v3_orig);
     }
 }
 
@@ -97,103 +130,6 @@ unsafe fn iv_setup(iv: [i32; 2], counter: u64) -> __m256i {
 
 #[inline]
 #[target_feature(enable = "avx2")]
-unsafe fn rounds(
-    nrounds: usize,
-    d0: __m256i,
-    d1: __m256i,
-    d2: __m256i,
-    d3: __m256i,
-    output: &mut [u8],
-) {
-    let (mut v0, mut v1, mut v2, mut v3) = (d0, d1, d2, d3);
-
-    for _ in 0..(nrounds / 2) {
-        // a = ADD256_32(a,b); d = XOR256(d,a); d = ROL256_16(d);
-        v0 = _mm256_add_epi32(v0, v1);
-        v3 = _mm256_xor_si256(v3, v0);
-        v3 = _mm256_shuffle_epi8(
-            v3,
-            _mm256_set_epi8(
-                13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2, 13, 12, 15, 14, 9, 8, 11, 10,
-                5, 4, 7, 6, 1, 0, 3, 2,
-            ),
-        );
-
-        // c = ADD256_32(c,d); b = XOR256(b,c); b = ROL256_12(b);
-        v2 = _mm256_add_epi32(v2, v3);
-        v1 = _mm256_xor_si256(v1, v2);
-        v1 = _mm256_xor_si256(_mm256_slli_epi32(v1, 12), _mm256_srli_epi32(v1, 20));
-
-        // a = ADD256_32(a,b); d = XOR256(d,a); d = ROL256_8(d);
-        v0 = _mm256_add_epi32(v0, v1);
-        v3 = _mm256_xor_si256(v3, v0);
-        v3 = _mm256_shuffle_epi8(
-            v3,
-            _mm256_set_epi8(
-                14, 13, 12, 15, 10, 9, 8, 11, 6, 5, 4, 7, 2, 1, 0, 3, 14, 13, 12, 15, 10, 9, 8, 11,
-                6, 5, 4, 7, 2, 1, 0, 3,
-            ),
-        );
-
-        // c = ADD256_32(c,d); b = XOR256(b,c); b = ROL256_7(b);
-        v2 = _mm256_add_epi32(v2, v3);
-        v1 = _mm256_xor_si256(v1, v2);
-        v1 = _mm256_xor_si256(_mm256_slli_epi32(v1, 7), _mm256_srli_epi32(v1, 25));
-
-        // b = ROR256_V1(b); c = ROR256_V2(c); d = ROR256_V3(d);
-        v1 = _mm256_shuffle_epi32(v1, (3 << 4) | (2 << 2) | 1);
-        v2 = _mm256_shuffle_epi32(v2, (1 << 6) | (3 << 2) | 2);
-        v3 = _mm256_shuffle_epi32(v3, (2 << 6) | (1 << 4) | 3);
-
-        // a = ADD256_32(a,b); d = XOR256(d,a); d = ROL256_16(d);
-        v0 = _mm256_add_epi32(v0, v1);
-        v3 = _mm256_xor_si256(v3, v0);
-        v3 = _mm256_shuffle_epi8(
-            v3,
-            _mm256_set_epi8(
-                13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2, 13, 12, 15, 14, 9, 8, 11, 10,
-                5, 4, 7, 6, 1, 0, 3, 2,
-            ),
-        );
-
-        // c = ADD256_32(c,d); b = XOR256(b,c); b = ROL256_12(b);
-        v2 = _mm256_add_epi32(v2, v3);
-        v1 = _mm256_xor_si256(v1, v2);
-        v1 = _mm256_xor_si256(_mm256_slli_epi32(v1, 12), _mm256_srli_epi32(v1, 20));
-
-        // a = ADD256_32(a,b); d = XOR256(d,a); d = ROL256_8(d);
-        v0 = _mm256_add_epi32(v0, v1);
-        v3 = _mm256_xor_si256(v3, v0);
-        v3 = _mm256_shuffle_epi8(
-            v3,
-            _mm256_set_epi8(
-                14, 13, 12, 15, 10, 9, 8, 11, 6, 5, 4, 7, 2, 1, 0, 3, 14, 13, 12, 15, 10, 9, 8, 11,
-                6, 5, 4, 7, 2, 1, 0, 3,
-            ),
-        );
-
-        // c = ADD256_32(c,d); b = XOR256(b,c); b = ROL256_7(b);
-        v2 = _mm256_add_epi32(v2, v3);
-        v1 = _mm256_xor_si256(v1, v2);
-        v1 = _mm256_xor_si256(_mm256_slli_epi32(v1, 7), _mm256_srli_epi32(v1, 25));
-
-        // b = ROR256_V3(b); c = ROR256_V2(c); d = ROR256_V1(d);
-        v1 = _mm256_shuffle_epi32(v1, (2 << 6) | (1 << 4) | 3);
-        v2 = _mm256_shuffle_epi32(v2, (1 << 6) | (3 << 2) | 2);
-        v3 = _mm256_shuffle_epi32(v3, (3 << 4) | (2 << 2) | 1);
-    }
-
-    store(
-        _mm256_add_epi32(v0, d0),
-        _mm256_add_epi32(v1, d1),
-        _mm256_add_epi32(v2, d2),
-        _mm256_add_epi32(v3, d3),
-        output,
-    )
-}
-
-#[inline]
-#[target_feature(enable = "avx2")]
 #[allow(clippy::cast_ptr_alignment)] // storeu supports unaligned stores
 unsafe fn store(v0: __m256i, v1: __m256i, v2: __m256i, v3: __m256i, output: &mut [u8]) {
     _mm_storeu_si128(
@@ -212,4 +148,72 @@ unsafe fn store(v0: __m256i, v1: __m256i, v2: __m256i, v3: __m256i, output: &mut
         output.as_mut_ptr().offset(0x30) as *mut __m128i,
         _mm256_castsi256_si128(v3),
     );
+}
+
+#[inline]
+#[target_feature(enable = "avx2")]
+unsafe fn double_quarter_round(
+    v0: &mut __m256i,
+    v1: &mut __m256i,
+    v2: &mut __m256i,
+    v3: &mut __m256i,
+) {
+    add_xor_rot(v0, v1, v2, v3);
+    rows_to_cols(v0, v1, v2, v3);
+    add_xor_rot(v0, v1, v2, v3);
+    cols_to_rows(v0, v1, v2, v3);
+}
+
+#[inline]
+#[target_feature(enable = "avx2")]
+unsafe fn rows_to_cols(_v0: &mut __m256i, v1: &mut __m256i, v2: &mut __m256i, v3: &mut __m256i) {
+    // b = ROR256_V1(b); c = ROR256_V2(c); d = ROR256_V3(d);
+    *v1 = _mm256_shuffle_epi32(*v1, 0b_00_11_10_01); // _MM_SHUFFLE(0, 3, 2, 1)
+    *v2 = _mm256_shuffle_epi32(*v2, 0b_01_00_11_10); // _MM_SHUFFLE(1, 0, 3, 2)
+    *v3 = _mm256_shuffle_epi32(*v3, 0b_10_01_00_11); // _MM_SHUFFLE(2, 1, 0, 3)
+}
+
+#[inline]
+#[target_feature(enable = "avx2")]
+unsafe fn cols_to_rows(_v0: &mut __m256i, v1: &mut __m256i, v2: &mut __m256i, v3: &mut __m256i) {
+    // b = ROR256_V3(b); c = ROR256_V2(c); d = ROR256_V1(d);
+    *v1 = _mm256_shuffle_epi32(*v1, 0b_10_01_00_11); // _MM_SHUFFLE(2, 1, 0, 3)
+    *v2 = _mm256_shuffle_epi32(*v2, 0b_01_00_11_10); // _MM_SHUFFLE(1, 0, 3, 2)
+    *v3 = _mm256_shuffle_epi32(*v3, 0b_00_11_10_01); // _MM_SHUFFLE(0, 3, 2, 1)
+}
+
+#[inline]
+#[target_feature(enable = "avx2")]
+unsafe fn add_xor_rot(v0: &mut __m256i, v1: &mut __m256i, v2: &mut __m256i, v3: &mut __m256i) {
+    // a = ADD256_32(a,b); d = XOR256(d,a); d = ROL256_16(d);
+    *v0 = _mm256_add_epi32(*v0, *v1);
+    *v3 = _mm256_xor_si256(*v3, *v0);
+    *v3 = _mm256_shuffle_epi8(
+        *v3,
+        _mm256_set_epi8(
+            13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2, 13, 12, 15, 14, 9, 8, 11, 10, 5,
+            4, 7, 6, 1, 0, 3, 2,
+        ),
+    );
+
+    // c = ADD256_32(c,d); b = XOR256(b,c); b = ROL256_12(b);
+    *v2 = _mm256_add_epi32(*v2, *v3);
+    *v1 = _mm256_xor_si256(*v1, *v2);
+    *v1 = _mm256_xor_si256(_mm256_slli_epi32(*v1, 12), _mm256_srli_epi32(*v1, 20));
+
+    // a = ADD256_32(a,b); d = XOR256(d,a); d = ROL256_8(d);
+    *v0 = _mm256_add_epi32(*v0, *v1);
+    *v3 = _mm256_xor_si256(*v3, *v0);
+    *v3 = _mm256_shuffle_epi8(
+        *v3,
+        _mm256_set_epi8(
+            14, 13, 12, 15, 10, 9, 8, 11, 6, 5, 4, 7, 2, 1, 0, 3, 14, 13, 12, 15, 10, 9, 8, 11, 6,
+            5, 4, 7, 2, 1, 0, 3,
+        ),
+    );
+
+    // c = ADD256_32(c,d); b = XOR256(b,c); b = ROL256_7(b);
+    *v2 = _mm256_add_epi32(*v2, *v3);
+    *v1 = _mm256_xor_si256(*v1, *v2);
+    *v1 = _mm256_xor_si256(_mm256_slli_epi32(*v1, 7), _mm256_srli_epi32(*v1, 25));
 }

--- a/chacha20/src/cipher.rs
+++ b/chacha20/src/cipher.rs
@@ -16,23 +16,42 @@ type Buffer = [u8; BLOCK_SIZE];
 
 /// ChaCha20 as a counter mode stream cipher
 pub(crate) struct Cipher {
+    /// ChaCha20 block function initialized with a key and IV
     block: Block,
+
+    /// Buffer containing previous block function output
     buffer: Buffer,
-    base_counter: u64,
+
+    /// Position within buffer, or `None` if the buffer is not in use
+    buffer_pos: Option<u8>,
+
+    /// Current counter value relative to the start of the keystream
     counter: u64,
-    pos: Option<u8>,
+
+    /// Offset of the initial counter in the keystream. This is derived from
+    /// the extra 4 bytes in the 96-byte nonce RFC 8439 version (or is always
+    /// 0 in the legacy version)
+    counter_offset: u64,
 }
 
 impl Cipher {
     /// Create new CTR mode cipher from the given block and starting counter
-    pub fn new(block: Block, base_counter: u64) -> Self {
+    pub fn new(block: Block, counter_offset: u64) -> Self {
         Self {
             block,
             buffer: [0u8; BLOCK_SIZE],
-            base_counter,
+            buffer_pos: None,
             counter: 0,
-            pos: None,
+            counter_offset,
         }
+    }
+
+    /// Generate a block, storing it in the internal buffer
+    #[inline]
+    fn generate_block(&mut self, counter: u64) {
+        // TODO(tarcieri): double check this should be checked and not wrapping
+        let counter_with_offset = self.counter_offset.checked_add(counter).unwrap();
+        self.block.generate(counter_with_offset, &mut self.buffer);
     }
 }
 
@@ -41,19 +60,19 @@ impl SyncStreamCipher for Cipher {
         self.check_data_len(data)?;
 
         // xor with leftover bytes from the last call if any
-        if let Some(pos) = self.pos {
+        if let Some(pos) = self.buffer_pos {
             let pos = pos as usize;
 
             if data.len() >= BLOCK_SIZE - pos {
                 let buf = &self.buffer[pos..];
-                let (r, l) = { data }.split_at_mut(buf.len());
+                let (r, l) = data.split_at_mut(buf.len());
                 data = l;
                 xor(r, buf);
-                self.pos = None;
+                self.buffer_pos = None;
             } else {
-                let buf = &self.buffer[pos..pos + data.len()];
+                let buf = &self.buffer[pos..pos.checked_add(data.len()).unwrap()];
                 xor(data, buf);
-                self.pos = Some((pos + data.len()) as u8);
+                self.buffer_pos = Some(pos.checked_add(data.len()).unwrap() as u8);
                 return Ok(());
             }
         }
@@ -63,17 +82,20 @@ impl SyncStreamCipher for Cipher {
         while data.len() >= BLOCK_SIZE {
             let (l, r) = { data }.split_at_mut(BLOCK_SIZE);
             data = r;
-            self.block.generate(self.base_counter + counter, l);
-            counter += 1;
+
+            // TODO(tarcieri): double check this should be checked and not wrapping
+            let counter_with_offset = self.counter_offset.checked_add(counter).unwrap();
+            self.block.apply_keystream(counter_with_offset, l);
+
+            counter = counter.checked_add(1).unwrap();
         }
 
         if !data.is_empty() {
-            self.block
-                .generate(self.base_counter + counter, &mut self.buffer);
-            counter += 1;
+            self.generate_block(counter);
+            counter = counter.checked_add(1).unwrap();
             let n = data.len();
             xor(data, &self.buffer[..n]);
-            self.pos = Some(n as u8);
+            self.buffer_pos = Some(n as u8);
         }
 
         self.counter = counter;
@@ -86,23 +108,26 @@ impl SyncStreamCipherSeek for Cipher {
     fn current_pos(&self) -> u64 {
         let bs = BLOCK_SIZE as u64;
 
-        match self.pos {
-            Some(pos) => self.counter.wrapping_sub(1) * bs + u64::from(pos),
-            None => self.counter * bs,
+        if let Some(pos) = self.buffer_pos {
+            (self.counter.wrapping_sub(1) * bs)
+                .checked_add(u64::from(pos))
+                .unwrap()
+        } else {
+            self.counter * bs
         }
     }
 
     fn seek(&mut self, pos: u64) {
         let bs = BLOCK_SIZE as u64;
         self.counter = pos / bs;
-        let l = (pos % bs) as u16;
-        if l == 0 {
-            self.pos = None;
+        let rem = pos % bs;
+
+        if rem == 0 {
+            self.buffer_pos = None;
         } else {
-            self.block
-                .generate(self.base_counter + self.counter, &mut self.buffer);
-            self.counter += 1;
-            self.pos = Some(l as u8);
+            self.generate_block(self.counter);
+            self.counter = self.counter.checked_add(1).unwrap();
+            self.buffer_pos = Some(rem as u8);
         }
     }
 }
@@ -110,10 +135,10 @@ impl SyncStreamCipherSeek for Cipher {
 impl Cipher {
     fn check_data_len(&self, data: &[u8]) -> Result<(), LoopError> {
         let dlen = data.len()
-            - match self.pos {
-                Some(pos) => cmp::min(BLOCK_SIZE - pos as usize, data.len()),
-                None => 0,
-            };
+            - self
+                .buffer_pos
+                .map(|pos| cmp::min(BLOCK_SIZE - pos as usize, data.len()))
+                .unwrap_or_default();
 
         let data_buffers = dlen / BLOCK_SIZE + if data.len() % BLOCK_SIZE != 0 { 1 } else { 0 };
 


### PR DESCRIPTION
Previously when looping through input data, if there was enough data to avoid buffering it was obliterating the plaintext with the keystream rather than XORing it.

This was addressed by adding an `apply_keystream` method to each backend for use in this situation, which avoids the intermediate buffer.

Additionally this commit refactors the AVX2 backend to look more like the SSE2 backend.