### PR TITLE
chacha20: Parallelize AVX2 backend

### DIFF
--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -36,7 +36,11 @@ xchacha20 = ["stream-cipher"]
 rng = ["rand_core"]
 
 [[bench]]
-name = "chacha20"
+name = "stream_cipher"
+harness = false
+
+[[bench]]
+name = "rng"
 harness = false
 
 [package.metadata.docs.rs]

--- a/chacha20/README.md
+++ b/chacha20/README.md
@@ -24,10 +24,12 @@ This crate contains the following implementations of ChaCha20, all of which
 work on stable Rust with the following `RUSTFLAGS`:
 
 - `x86` / `x86_64`
-  - `sse2`: `-Ctarget-feature=+sse2` (on by default on x86 CPUs)
-  - `avx2`: `-Ctarget-cpu=haswell -Ctarget-feature=+avx2`
+  - `avx2`: (~1.4cpb) `-Ctarget-cpu=haswell -Ctarget-feature=+avx2`
+  - `sse2`: (~2.5cpb) `-Ctarget-feature=+sse2` (on by default on x86 CPUs)
 - Portable
-  - `soft`
+  - `soft`: (~5 cpb on x86/x86_64)
+
+NOTE: cpb = cycles per byte (smaller is better)
 
 ## Security Warning
 

--- a/chacha20/benches/rng.rs
+++ b/chacha20/benches/rng.rs
@@ -1,15 +1,18 @@
+//! `ChaCha20Rng` benchmark
+
+#[cfg(not(feature = "rng"))]
+compile_error!("run benchmarks with `cargo bench --all-features`");
+
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use criterion_cycles_per_byte::CyclesPerByte;
 
-use chacha20::{
-    stream_cipher::{NewStreamCipher, SyncStreamCipher},
-    ChaCha20,
-};
+use chacha20::ChaCha20Rng;
+use rand_core::{RngCore, SeedableRng};
 
 const KB: usize = 1024;
 
 fn bench(c: &mut Criterion<CyclesPerByte>) {
-    let mut group = c.benchmark_group("chacha20");
+    let mut group = c.benchmark_group("rng");
 
     for size in &[KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB] {
         let mut buf = vec![0u8; *size];
@@ -17,11 +20,8 @@ fn bench(c: &mut Criterion<CyclesPerByte>) {
         group.throughput(Throughput::Bytes(*size as u64));
 
         group.bench_function(BenchmarkId::new("apply_keystream", size), |b| {
-            let key = Default::default();
-            let nonce = Default::default();
-            let mut cipher = ChaCha20::new(&key, &nonce);
-
-            b.iter(|| cipher.apply_keystream(&mut buf));
+            let mut rng = ChaCha20Rng::from_seed(Default::default());
+            b.iter(|| rng.fill_bytes(&mut buf));
         });
     }
 

--- a/chacha20/benches/stream_cipher.rs
+++ b/chacha20/benches/stream_cipher.rs
@@ -1,0 +1,41 @@
+//! ChaCha20 `stream-cipher` benchmark
+
+#[cfg(not(feature = "stream-cipher"))]
+compile_error!("run benchmarks with `cargo bench --all-features`");
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion_cycles_per_byte::CyclesPerByte;
+
+use chacha20::{
+    stream_cipher::{NewStreamCipher, SyncStreamCipher},
+    ChaCha20,
+};
+
+const KB: usize = 1024;
+
+fn bench(c: &mut Criterion<CyclesPerByte>) {
+    let mut group = c.benchmark_group("stream-cipher");
+
+    for size in &[KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB] {
+        let mut buf = vec![0u8; *size];
+
+        group.throughput(Throughput::Bytes(*size as u64));
+
+        group.bench_function(BenchmarkId::new("apply_keystream", size), |b| {
+            let key = Default::default();
+            let nonce = Default::default();
+            let mut cipher = ChaCha20::new(&key, &nonce);
+
+            b.iter(|| cipher.apply_keystream(&mut buf));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().with_measurement(CyclesPerByte);
+    targets = bench
+);
+criterion_main!(benches);

--- a/chacha20/src/block.rs
+++ b/chacha20/src/block.rs
@@ -21,20 +21,20 @@ mod avx2;
     any(target_arch = "x86", target_arch = "x86_64"),
     any(target_feature = "sse2", target_feature = "avx2")
 )))]
-pub(crate) use self::soft::Block;
+pub(crate) use self::soft::{Block, BUFFER_SIZE};
 
 #[cfg(all(
     any(target_arch = "x86", target_arch = "x86_64"),
     target_feature = "sse2",
     not(target_feature = "avx2")
 ))]
-pub(crate) use self::sse2::Block;
+pub(crate) use self::sse2::{Block, BUFFER_SIZE};
 
 #[cfg(all(
     any(target_arch = "x86", target_arch = "x86_64"),
     target_feature = "avx2"
 ))]
-pub(crate) use self::avx2::Block;
+pub(crate) use self::avx2::{Block, BUFFER_SIZE};
 
 use core::fmt::{self, Debug};
 

--- a/chacha20/src/block/soft.rs
+++ b/chacha20/src/block/soft.rs
@@ -8,11 +8,11 @@
 use crate::{BLOCK_SIZE, CONSTANTS, IV_SIZE, KEY_SIZE, STATE_WORDS};
 use core::{convert::TryInto, mem};
 
-/// The ChaCha20 block function
-///
-/// While ChaCha20 is a stream cipher, not a block cipher, its core
-/// primitive is a function which acts on a 512-bit block
-// TODO(tarcieri): zeroize? need to make sure we're actually copying first
+/// Size of buffers passed to `generate` and `apply_keystream` for this backend
+pub(crate) const BUFFER_SIZE: usize = BLOCK_SIZE;
+
+/// The ChaCha20 block function (portable software implementation)
+// TODO(tarcieri): zeroize?
 #[allow(dead_code)]
 #[derive(Clone)]
 pub(crate) struct Block {
@@ -49,7 +49,7 @@ impl Block {
 
     /// Generate output, overwriting data already in the buffer
     pub(crate) fn generate(&mut self, counter: u64, output: &mut [u8]) {
-        debug_assert_eq!(output.len(), BLOCK_SIZE);
+        debug_assert_eq!(output.len(), BUFFER_SIZE);
         self.counter_setup(counter);
 
         let mut state = self.state;
@@ -62,7 +62,7 @@ impl Block {
 
     /// Apply generated keystream to the output buffer
     pub(crate) fn apply_keystream(&mut self, counter: u64, output: &mut [u8]) {
-        debug_assert_eq!(output.len(), BLOCK_SIZE);
+        debug_assert_eq!(output.len(), BUFFER_SIZE);
         self.counter_setup(counter);
 
         let mut state = self.state;

--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -4,7 +4,10 @@ use core::slice;
 use rand_core::block::{BlockRng, BlockRngCore};
 use rand_core::{Error, RngCore, SeedableRng};
 
-use crate::{block::Block, BLOCK_SIZE, KEY_SIZE, STATE_WORDS};
+use crate::{
+    block::{Block, BUFFER_SIZE},
+    KEY_SIZE,
+};
 
 macro_rules! impl_chacha_rng {
     ($name:ident, $core:ident, $rounds:expr, $doc:expr) => {
@@ -63,12 +66,12 @@ macro_rules! impl_chacha_rng {
 
         impl BlockRngCore for $core {
             type Item = u32;
-            type Results = [u32; STATE_WORDS];
+            type Results = [u32; BUFFER_SIZE / 4];
 
             fn generate(&mut self, results: &mut Self::Results) {
                 // TODO(tarcieri): eliminate unsafety (replace w\ [u8; BLOCK_SIZE)
                 self.block.generate(self.counter, unsafe {
-                    slice::from_raw_parts_mut(results.as_mut_ptr() as *mut u8, BLOCK_SIZE)
+                    slice::from_raw_parts_mut(results.as_mut_ptr() as *mut u8, BUFFER_SIZE)
                 });
                 self.counter += 1;
             }


### PR DESCRIPTION
The AVX2 backend was previously computing two ChaCha blocks in parallel, then throwing one away.

This updates the implementation to always compute two blocks in parallel when the AVX2 backend is enabled, resulting in a ~2X speedup.

Unfortunately for `cipher.rs`, originally adapted from the `ctr` crate, I deleted the original parallel computation code, and in lieu of that the implementation diverges from what was originally in `ctr`. See here for a reference:

https://github.com/RustCrypto/stream-ciphers/blob/907e94b/ctr/src/lib.rs#L73

Ideally we can come up with some generic counter management and buffering abstraction in the `ctr` crate which works in all cases.

Benchmark results:

<img width="624" alt="Screen Shot 2020-01-16 at 7 46 49 AM" src="https://user-images.githubusercontent.com/797/72542005-4da1e100-3838-11ea-9778-e77025160d2b.png">
