### PR TITLE
chacha20 v0.3.2

### DIFF
--- a/chacha20/CHANGES.md
+++ b/chacha20/CHANGES.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.2 (2020-01-17)
+### Added
+- `CryptoRng` marker on all `ChaCha*Rng` types ([#91])
+
+[#91]: https://github.com/RustCrypto/stream-ciphers/pull/91
+
 ## 0.3.1 (2020-01-16)
 ### Added
 - Parallelize AVX2 backend ([#87])

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
- `CryptoRng` marker on all `ChaCha*Rng` types ([#91])

[#91]: https://github.com/RustCrypto/stream-ciphers/pull/91