### PR TITLE
salsa20 v0.4.0

### DIFF
--- a/salsa20/CHANGES.md
+++ b/salsa20/CHANGES.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-01-17)
+### Changed
+- Replace `salsa20-core` with `ctr`-derived buffering; MSRV 1.34+ ([#94])
+
+[#94]: https://github.com/RustCrypto/stream-ciphers/pull/94
+
 ## 0.3.0 (2019-10-01)
 ### Added
 - XSalsa20 ([#54])

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa20"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Salsa20 Stream Cipher"

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -34,7 +34,8 @@
 //! ```
 
 #![no_std]
-#![deny(missing_docs)]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
 
 pub use stream_cipher;
 


### PR DESCRIPTION
### Changed
- Replace `salsa20-core` with `ctr`-derived buffering; MSRV 1.34+ ([#94])

[#94]: https://github.com/RustCrypto/stream-ciphers/pull/94