### PR TITLE
chacha20: fix warnings when building with `rng` feature alone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ matrix:
     # chacha20 crate with SSE2 and AVX2 backends
     - name: "Rust: stable (chacha20)"
       rust: stable
-      env:
       script:
         - RUSTFLAGS="-Ctarget-feature=+sse2" cargo test --package chacha20 --release
         - RUSTFLAGS="-Ctarget-feature=+avx2" cargo test --package chacha20 --release

--- a/chacha20/src/block/avx2.rs
+++ b/chacha20/src/block/avx2.rs
@@ -66,6 +66,7 @@ impl Block {
     }
 
     #[inline]
+    #[cfg(feature = "stream-cipher")]
     #[allow(clippy::cast_ptr_alignment)] // loadu/storeu support unaligned loads/stores
     pub(crate) fn apply_keystream(&self, counter: u64, output: &mut [u8]) {
         debug_assert_eq!(output.len(), BUFFER_SIZE);

--- a/chacha20/src/block/soft.rs
+++ b/chacha20/src/block/soft.rs
@@ -48,6 +48,7 @@ impl Block {
     }
 
     /// Generate output, overwriting data already in the buffer
+    #[inline]
     pub(crate) fn generate(&mut self, counter: u64, output: &mut [u8]) {
         debug_assert_eq!(output.len(), BUFFER_SIZE);
         self.counter_setup(counter);
@@ -61,6 +62,8 @@ impl Block {
     }
 
     /// Apply generated keystream to the output buffer
+    #[inline]
+    #[cfg(feature = "stream-cipher")]
     pub(crate) fn apply_keystream(&mut self, counter: u64, output: &mut [u8]) {
         debug_assert_eq!(output.len(), BUFFER_SIZE);
         self.counter_setup(counter);

--- a/chacha20/src/block/sse2.rs
+++ b/chacha20/src/block/sse2.rs
@@ -63,6 +63,7 @@ impl Block {
     }
 
     #[inline]
+    #[cfg(feature = "stream-cipher")]
     #[allow(clippy::cast_ptr_alignment)] // loadu/storeu support unaligned loads/stores
     pub(crate) fn apply_keystream(&self, counter: u64, output: &mut [u8]) {
         debug_assert_eq!(output.len(), BUFFER_SIZE);

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -52,7 +52,7 @@
 
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
-#![deny(missing_docs)]
+#![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
 
 #[cfg(feature = "stream-cipher")]
 pub use stream_cipher;

--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -105,9 +105,9 @@ impl_chacha_rng!(
 
 #[cfg(test)]
 mod tests {
-    use crate::KEY_SIZE;
     use super::ChaCha20Rng;
-    use rand_core::{SeedableRng, RngCore};
+    use crate::KEY_SIZE;
+    use rand_core::{RngCore, SeedableRng};
 
     const KEY: [u8; KEY_SIZE] = [
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
@@ -120,9 +120,15 @@ mod tests {
         let mut bytes = [0u8; 13];
 
         rng.fill_bytes(&mut bytes);
-        assert_eq!(bytes, [177, 105, 126, 159, 198, 70, 30, 25, 131, 209, 49, 207, 105]);
+        assert_eq!(
+            bytes,
+            [177, 105, 126, 159, 198, 70, 30, 25, 131, 209, 49, 207, 105]
+        );
 
         rng.fill_bytes(&mut bytes);
-        assert_eq!(bytes, [167, 163, 252, 19, 79, 20, 152, 128, 232, 187, 43, 93, 35]);
+        assert_eq!(
+            bytes,
+            [167, 163, 252, 19, 79, 20, 152, 128, 232, 187, 43, 93, 35]
+        );
     }
 }


### PR DESCRIPTION
Seems these weren't caught because `-D warnings` was being cleared from the environment.