### PR TITLE
chacha20: replace macros with Rounds trait + generics

### DIFF
--- a/chacha20/src/block.rs
+++ b/chacha20/src/block.rs
@@ -4,6 +4,8 @@
 
 pub(crate) mod soft;
 
+use crate::rounds::Rounds;
+
 #[cfg(all(
     any(target_arch = "x86", target_arch = "x86_64"),
     target_feature = "sse2",
@@ -39,7 +41,7 @@ pub(crate) use self::avx2::{Block, BUFFER_SIZE};
 use core::fmt::{self, Debug};
 
 /// Common debug impl for all blocks
-impl Debug for Block {
+impl<R: Rounds> Debug for Block<R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         f.write_str("Block {{  .. }}")
     }

--- a/chacha20/src/legacy.rs
+++ b/chacha20/src/legacy.rs
@@ -1,7 +1,6 @@
 //! Legacy version of ChaCha20 with a 64-bit nonce
 
-use crate::{block::Block, cipher::Cipher};
-use core::convert::TryInto;
+use crate::cipher::ChaCha20;
 use stream_cipher::generic_array::{
     typenum::{U32, U8},
     GenericArray,
@@ -11,7 +10,7 @@ use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCiph
 /// The ChaCha20 stream cipher (legacy "djb" construction with 64-bit nonce).
 ///
 /// The `legacy` Cargo feature must be enabled to use this.
-pub struct ChaCha20Legacy(Cipher);
+pub struct ChaCha20Legacy(ChaCha20);
 
 impl NewStreamCipher for ChaCha20Legacy {
     /// Key size in bytes
@@ -21,13 +20,9 @@ impl NewStreamCipher for ChaCha20Legacy {
     type NonceSize = U8;
 
     fn new(key: &GenericArray<u8, Self::KeySize>, iv: &GenericArray<u8, Self::NonceSize>) -> Self {
-        let block = Block::new(
-            key.as_ref().try_into().unwrap(),
-            iv.as_ref().try_into().unwrap(),
-            20,
-        );
-
-        ChaCha20Legacy(Cipher::new(block, 0))
+        let mut exp_iv = GenericArray::default();
+        exp_iv[4..].copy_from_slice(iv);
+        ChaCha20Legacy(ChaCha20::new(key, &exp_iv))
     }
 }
 

--- a/chacha20/src/rounds.rs
+++ b/chacha20/src/rounds.rs
@@ -1,0 +1,29 @@
+//! Numbers of rounds allowed to be used with the ChaCha stream cipher
+
+pub trait Rounds: Copy {
+    const COUNT: usize;
+}
+
+/// 8-rounds
+#[derive(Copy, Clone)]
+pub struct R8;
+
+impl Rounds for R8 {
+    const COUNT: usize = 8;
+}
+
+/// 12-rounds
+#[derive(Copy, Clone)]
+pub struct R12;
+
+impl Rounds for R12 {
+    const COUNT: usize = 12;
+}
+
+/// 20-rounds
+#[derive(Copy, Clone)]
+pub struct R20;
+
+impl Rounds for R20 {
+    const COUNT: usize = 20;
+}

--- a/chacha20/src/xchacha20.rs
+++ b/chacha20/src/xchacha20.rs
@@ -1,6 +1,6 @@
 //! XChaCha20 is an extended nonce variant of ChaCha20
 
-use crate::{block::soft::quarter_round, ChaCha20, CONSTANTS};
+use crate::{block::soft::quarter_round, cipher::ChaCha20, CONSTANTS};
 use core::convert::TryInto;
 use stream_cipher::generic_array::{
     typenum::{U16, U24, U32},

--- a/salsa20/src/cipher.rs
+++ b/salsa20/src/cipher.rs
@@ -2,7 +2,7 @@
 //!
 //! Adapted from the `ctr` crate.
 
-// TODO(tarcieri): figure out how to unify this with the `ctr` crate
+// TODO(tarcieri): figure out how to unify this with the `ctr` crate (see #95)
 
 use crate::{block::Block, BLOCK_SIZE};
 use core::{


### PR DESCRIPTION
Previously macros were used to generate the ChaCha8, ChaCha12, and ChaCha20 variants of the ChaCha family.

This commit replaces them with a `Rounds` trait, making the `Cipher` type generic over `Rounds`, and replacing the `ChaCha8`, `ChaCha12`, and `ChaCha20` wrappers with type aliases.

In addition to everything else, this makes the number of rounds type safe in that they can only be `R8`, `R12`, or `R20`, eliminating runtime checks around the number of rounds, and also ensuring the number is a constant value known at compile time, which should improve optimizations.

The random number generator types are still generated by macros, unfortunately, but these can be fixed up in a different pass.