### PR TITLE
chacha20 v0.3.3

### DIFF
--- a/chacha20/CHANGES.md
+++ b/chacha20/CHANGES.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.3 (2020-01-18)
+### Changed
+- Replace macros with `Rounds` trait + generics ([#100])
+
+### Fixed
+- Fix warnings when building with `rng` feature alone ([#99])
+
+[#99]: https://github.com/RustCrypto/stream-ciphers/pull/99
+[#100]: https://github.com/RustCrypto/stream-ciphers/pull/100
+
 ## 0.3.2 (2020-01-17)
 ### Added
 - `CryptoRng` marker on all `ChaCha*Rng` types ([#91])

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/chacha20/src/cipher.rs
+++ b/chacha20/src/cipher.rs
@@ -38,7 +38,12 @@ type Buffer = [u8; BUFFER_SIZE];
 // See: <https://github.com/RustCrypto/stream-ciphers/blob/907e94b/ctr/src/lib.rs#L73>
 const COUNTER_INCR: u64 = (BUFFER_SIZE as u64) / (BLOCK_SIZE as u64);
 
-/// ChaCha20 as a counter mode stream cipher
+/// ChaCha family stream cipher, generic around a number of rounds.
+///
+/// Use the [`ChaCha8`], [`ChaCha12`], or [`ChaCha20`] type aliases to select
+/// a specific number of rounds.
+///
+/// Generally [`ChaCha20`] is preferred.
 pub struct Cipher<R: Rounds> {
     /// ChaCha20 block function initialized with a key and IV
     block: Block<R>,


### PR DESCRIPTION
### Changed
- Replace macros with `Rounds` trait + generics ([#100])

### Fixed
- Fix warnings when building with `rng` feature alone ([#99])

[#99]: https://github.com/RustCrypto/stream-ciphers/pull/99
[#100]: https://github.com/RustCrypto/stream-ciphers/pull/100