### PR TITLE
salsa20: add `hsalsa20` feature

### DIFF
--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -19,10 +19,8 @@ stream-cipher = { version = "0.3", features = ["dev"] }
 
 [features]
 default = ["xsalsa20"]
+hsalsa20 = ["xsalsa20"]
 xsalsa20 = []
 
 [badges]
 travis-ci = { repository = "RustCrypto/stream-ciphers" }
-
-[package.metadata.docs.rs]
-all-features = true

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -47,6 +47,9 @@ mod xsalsa20;
 #[cfg(feature = "xsalsa20")]
 pub use self::xsalsa20::XSalsa20;
 
+#[cfg(feature = "hsalsa20")]
+pub use self::xsalsa20::hsalsa20;
+
 use crate::{block::Block, cipher::Cipher};
 use core::convert::TryInto;
 use stream_cipher::generic_array::typenum::{U32, U8};

--- a/salsa20/src/xsalsa20.rs
+++ b/salsa20/src/xsalsa20.rs
@@ -59,18 +59,18 @@ impl SyncStreamCipherSeek for XSalsa20 {
     }
 }
 
+/// The HSalsa20 function defined in the paper "Extending the Salsa20 nonce"
+///
+/// <https://cr.yp.to/snuffle/xsalsa-20110204.pdf>
+///
 /// HSalsa20 takes 512-bits of input:
 ///
-/// * Constants (`u32` x 4)
-/// * Key (`u32` x 8)
-/// * Nonce (`u32` x 4)
+/// - Constants (`u32` x 4)
+/// - Key (`u32` x 8)
+/// - Nonce (`u32` x 4)
 ///
 /// It produces 256-bits of output suitable for use as a Salsa20 key
-///
-/// For more information on HSalsa20, see:
-///
-/// <http://cr.yp.to/snuffle/xsalsa-20110204.pdf>
-fn hsalsa20(key: &GenericArray<u8, U32>, input: &GenericArray<u8, U16>) -> GenericArray<u8, U32> {
+pub fn hsalsa20(key: &GenericArray<u8, U32>, input: &GenericArray<u8, U16>) -> GenericArray<u8, U32> {
     let mut state = [0u32; 16];
 
     state[0] = CONSTANTS[0];


### PR DESCRIPTION
Optionally exposes the `hsalsa20` function (for use in implementing e.g. `crypto_box`) under an off-by-default Cargo feature.