### PR TITLE
salsa20 v0.4.1

### DIFF
--- a/salsa20/CHANGES.md
+++ b/salsa20/CHANGES.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2020-02-25)
+### Added
+- `hsalsa20` feature ([#103])
+
+[#103]: https://github.com/RustCrypto/stream-ciphers/pull/103
+
 ## 0.4.0 (2020-01-17)
 ### Changed
 - Replace `salsa20-core` with `ctr`-derived buffering; MSRV 1.34+ ([#94])

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa20"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Salsa20 Stream Cipher"


### PR DESCRIPTION
### Added
- `hsalsa20` feature ([#103])

[#103]: https://github.com/RustCrypto/stream-ciphers/pull/103