### PR TITLE
Cargo.toml: avoid accidental `alloc` and `std` linking

### DIFF
--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -20,9 +20,9 @@ edition = "2018"
 travis-ci = { repository = "RustCrypto/stream-ciphers" }
 
 [dependencies]
-rand_core = { version = "0.5", optional = true }
+rand_core = { version = "0.5", optional = true, default-features = false }
 stream-cipher = { version = "0.3", optional = true }
-zeroize = { version = "1", optional = true }
+zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 stream-cipher = { version = "0.3", features = ["dev"] }


### PR DESCRIPTION
- `zeroize` was accidentally linking against `alloc`
- `rand_core` accidentally linked against `std`