### PR TITLE
.github: cache ChaCha20 test artifacts

### DIFF
--- a/.github/workflows/chacha20.yml
+++ b/.github/workflows/chacha20.yml
@@ -31,6 +31,9 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: -D warnings
         working-directory: chacha20
   test:
     runs-on: ubuntu-latest
@@ -41,20 +44,48 @@ jobs:
           - stable
     steps:
       - uses: actions/checkout@v1
+
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-rust-${{ matrix.toolchain }}-${{ matrix.target }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
+
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+
       - run: cargo test
-        working-directory: chacha20
-      - run: cargo test --release
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-Dwarnings"
         working-directory: chacha20
       - run: cargo test --release
         env:
-          RUSTFLAGS: "-Ctarget-feature=+sse2"
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-Dwarnings"
         working-directory: chacha20
       - run: cargo test --release
         env:
-          RUSTFLAGS: "-Ctarget-feature=+avx2"
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-Ctarget-feature=+sse2 -Dwarnings"
+        working-directory: chacha20
+      - run: cargo test --release
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-Ctarget-feature=+avx2 -Dwarnings"
         working-directory: chacha20

--- a/chacha20/README.md
+++ b/chacha20/README.md
@@ -1,4 +1,4 @@
-# ChaCha20
+# RustCrypto: ChaCha20
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]

--- a/chacha20/src/block.rs
+++ b/chacha20/src/block.rs
@@ -2,6 +2,9 @@
 //!
 //! <https://tools.ietf.org/html/rfc8439#section-2.3>
 
+// TODO(tarcieri): figure out what circumstances these occur in
+#![allow(unused_imports)]
+
 pub(crate) mod soft;
 
 use crate::rounds::Rounds;


### PR DESCRIPTION
This crate has a lot of dependencies by way of Criterion. Caching them should help the build performance.