### PR TITLE
ctr: 2018 edition and `stream-cipher` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,19 +6,29 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54eb1d8fe354e5fc611daf4f2ea97dd45a765f4f1e4512306ec183ae2e8f20c9"
 dependencies = [
- "aes-soft",
- "aesni",
+ "aes-soft 0.3.3",
+ "aesni 0.6.0",
  "block-cipher-trait",
+]
+
+[[package]]
+name = "aes"
+version = "0.4.0-pre"
+source = "git+https://github.com/RustCrypto/block-ciphers#044bc4ce9c0634871790cfae7e4d6a1d6e252516"
+dependencies = [
+ "aes-soft 0.4.0-pre",
+ "aesni 0.7.0-pre",
+ "block-cipher",
 ]
 
 [[package]]
 name = "aes-ctr"
 version = "0.3.0"
 dependencies = [
- "aes-soft",
- "aesni",
+ "aes-soft 0.3.3",
+ "aesni 0.6.0",
  "ctr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "stream-cipher",
+ "stream-cipher 0.3.2",
 ]
 
 [[package]]
@@ -33,6 +43,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-soft"
+version = "0.4.0-pre"
+source = "git+https://github.com/RustCrypto/block-ciphers#044bc4ce9c0634871790cfae7e4d6a1d6e252516"
+dependencies = [
+ "block-cipher",
+ "byteorder",
+ "opaque-debug",
+]
+
+[[package]]
 name = "aesni"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,7 +60,16 @@ checksum = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
 dependencies = [
  "block-cipher-trait",
  "opaque-debug",
- "stream-cipher",
+ "stream-cipher 0.3.2",
+]
+
+[[package]]
+name = "aesni"
+version = "0.7.0-pre"
+source = "git+https://github.com/RustCrypto/block-ciphers#044bc4ce9c0634871790cfae7e4d6a1d6e252516"
+dependencies = [
+ "block-cipher",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -76,13 +105,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-cipher"
+version = "0.7.0-pre"
+source = "git+https://github.com/RustCrypto/traits#8f24286f0aa22d9f98a3edbe859a890d5d0d879e"
+dependencies = [
+ "generic-array 0.14.1",
+]
+
+[[package]]
 name = "block-cipher-trait"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 dependencies = [
  "blobby",
- "generic-array",
+ "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -122,20 +159,20 @@ dependencies = [
 name = "cfb-mode"
 version = "0.3.2"
 dependencies = [
- "aes",
+ "aes 0.3.2",
  "block-cipher-trait",
  "hex-literal",
- "stream-cipher",
+ "stream-cipher 0.3.2",
 ]
 
 [[package]]
 name = "cfb8"
 version = "0.3.2"
 dependencies = [
- "aes",
+ "aes 0.3.2",
  "block-cipher-trait",
  "hex-literal",
- "stream-cipher",
+ "stream-cipher 0.3.2",
 ]
 
 [[package]]
@@ -151,7 +188,7 @@ dependencies = [
  "criterion",
  "criterion-cycles-per-byte",
  "rand_core",
- "stream-cipher",
+ "stream-cipher 0.3.2",
  "zeroize",
 ]
 
@@ -283,10 +320,10 @@ dependencies = [
 name = "ctr"
 version = "0.3.2"
 dependencies = [
- "aes",
+ "aes 0.4.0-pre",
  "blobby",
- "block-cipher-trait",
- "stream-cipher",
+ "block-cipher",
+ "stream-cipher 0.4.0-pre",
 ]
 
 [[package]]
@@ -296,7 +333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "022cd691704491df67d25d006fe8eca083098253c4d43516c2206479c58c6736"
 dependencies = [
  "block-cipher-trait",
- "stream-cipher",
+ "stream-cipher 0.3.2",
 ]
 
 [[package]]
@@ -315,11 +352,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2664c2cf08049036f31015b04c6ac3671379a1d86f52ed2416893f16022deb"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hc-256"
 version = "0.0.1"
 dependencies = [
  "block-cipher-trait",
- "stream-cipher",
+ "stream-cipher 0.3.2",
  "zeroize",
 ]
 
@@ -440,10 +486,10 @@ dependencies = [
 name = "ofb"
 version = "0.1.1"
 dependencies = [
- "aes",
+ "aes 0.3.2",
  "block-cipher-trait",
  "hex-literal",
- "stream-cipher",
+ "stream-cipher 0.3.2",
 ]
 
 [[package]]
@@ -576,7 +622,7 @@ checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 name = "salsa20"
 version = "0.4.1"
 dependencies = [
- "stream-cipher",
+ "stream-cipher 0.3.2",
  "zeroize",
 ]
 
@@ -645,7 +691,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
 dependencies = [
  "blobby",
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "stream-cipher"
+version = "0.4.0-pre"
+source = "git+https://github.com/RustCrypto/traits#8f24286f0aa22d9f98a3edbe859a890d5d0d879e"
+dependencies = [
+ "blobby",
+ "generic-array 0.14.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ members = [
     "ofb",
     "salsa20",
 ]
+
+[patch.crates-io]
+block-cipher = { git = "https://github.com/RustCrypto/traits" }

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -8,14 +8,16 @@ documentation = "https://docs.rs/ctr"
 repository = "https://github.com/RustCrypto/stream-ciphers"
 keywords = ["crypto", "stream-cipher", "trait"]
 categories = ["cryptography", "no-std"]
+readme = "README.md"
+edition = "2018"
 
 [dependencies]
-stream-cipher = "0.3"
-block-cipher-trait = "0.6"
+stream-cipher = { version = "= 0.4.0-pre", git = "https://github.com/RustCrypto/traits" }
+block-cipher = "0.7.0-pre"
 
 [dev-dependencies]
-aes = "0.3"
-stream-cipher = { version = "0.3", features = ["dev"] }
+aes = { version = "= 0.4.0-pre", git = "https://github.com/RustCrypto/block-ciphers" }
+stream-cipher = { version = "= 0.4.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
 blobby = "0.1"
 
 [badges]

--- a/ctr/benches/aes128.rs
+++ b/ctr/benches/aes128.rs
@@ -1,8 +1,8 @@
 #![feature(test)]
 #[macro_use]
 extern crate stream_cipher;
-extern crate aes;
-extern crate ctr;
+use aes;
+use ctr;
 
 type Aes128Ctr = ctr::Ctr128<aes::Aes128>;
 

--- a/ctr/src/lib.rs
+++ b/ctr/src/lib.rs
@@ -42,16 +42,15 @@
 #![allow(clippy::needless_doctest_main)]
 #![deny(missing_docs)]
 
-extern crate block_cipher_trait;
-pub extern crate stream_cipher;
+pub use stream_cipher;
 
 use stream_cipher::{
     InvalidKeyNonceLength, LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek,
 };
 
-use block_cipher_trait::generic_array::typenum::{Unsigned, U16};
-use block_cipher_trait::generic_array::{ArrayLength, GenericArray};
-use block_cipher_trait::BlockCipher;
+use block_cipher::generic_array::typenum::{Unsigned, U16};
+use block_cipher::generic_array::{ArrayLength, GenericArray};
+use block_cipher::{BlockCipher, NewBlockCipher};
 use core::{cmp, fmt, mem, ptr};
 
 #[inline(always)]
@@ -116,7 +115,7 @@ fn to_slice<C: BlockCipher>(blocks: &Blocks<C>) -> &[u8] {
 
 impl<C> NewStreamCipher for Ctr128<C>
 where
-    C: BlockCipher<BlockSize = U16>,
+    C: NewBlockCipher + BlockCipher<BlockSize = U16>,
     C::ParBlocks: ArrayLength<GenericArray<u8, U16>>,
 {
     type KeySize = C::KeySize;
@@ -290,7 +289,7 @@ where
     C: BlockCipher<BlockSize = U16>,
     C::ParBlocks: ArrayLength<GenericArray<u8, U16>>,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "Ctr128 {{ .. }}")
     }
 }

--- a/ctr/tests/mod.rs
+++ b/ctr/tests/mod.rs
@@ -1,11 +1,11 @@
-extern crate aes;
-extern crate blobby;
-extern crate ctr;
+use aes;
+use blobby;
+use ctr;
 #[macro_use]
 extern crate stream_cipher;
 
-use aes::block_cipher_trait::generic_array::GenericArray;
-use aes::block_cipher_trait::BlockCipher;
+use aes::block_cipher::generic_array::GenericArray;
+use aes::block_cipher::NewBlockCipher;
 use stream_cipher::SyncStreamCipher;
 
 type Aes128Ctr = ctr::Ctr128<aes::Aes128>;


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `stream-cipher` v0.4.0-pre crate.