### PR TITLE
cfb-mode: 2018 edition and `stream-cipher` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,10 +159,10 @@ dependencies = [
 name = "cfb-mode"
 version = "0.3.2"
 dependencies = [
- "aes 0.3.2",
- "block-cipher-trait",
+ "aes 0.4.0-pre",
+ "block-cipher",
  "hex-literal",
- "stream-cipher 0.3.2",
+ "stream-cipher 0.4.0-pre",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 ]
 
 [patch.crates-io]
+aes = { git = "https://github.com/RustCrypto/block-ciphers" }
 aesni = { git = "https://github.com/RustCrypto/block-ciphers" }
 aes-soft = { git = "https://github.com/RustCrypto/block-ciphers" }
 block-cipher = { git = "https://github.com/RustCrypto/traits" }

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -9,14 +9,15 @@ repository = "https://github.com/RustCrypto/stream-ciphers"
 keywords = ["crypto", "stream-cipher", "block-mode"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
-stream-cipher = "0.3"
-block-cipher-trait = "0.6"
+stream-cipher = "= 0.4.0-pre"
+block-cipher = "= 0.7.0-pre"
 
 [dev-dependencies]
-aes = "0.3"
-stream-cipher = { version = "0.3", features = ["dev"] }
+aes = "= 0.4.0-pre"
+stream-cipher = { version = "= 0.4.0-pre", features = ["dev"] }
 hex-literal = "0.1"
 
 [badges]

--- a/cfb-mode/benches/cfb-mode.rs
+++ b/cfb-mode/benches/cfb-mode.rs
@@ -1,8 +1,8 @@
 #![feature(test)]
 #[macro_use]
 extern crate stream_cipher;
-extern crate aes;
-extern crate cfb_mode;
+use aes;
+use cfb_mode;
 
 type Aes128Cfb = cfb_mode::Cfb<aes::Aes128>;
 

--- a/cfb-mode/src/lib.rs
+++ b/cfb-mode/src/lib.rs
@@ -48,12 +48,12 @@
 #![no_std]
 #![deny(missing_docs)]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
-extern crate block_cipher_trait;
-pub extern crate stream_cipher;
 
-use block_cipher_trait::generic_array::typenum::Unsigned;
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::BlockCipher;
+pub use stream_cipher;
+
+use block_cipher::generic_array::typenum::Unsigned;
+use block_cipher::generic_array::GenericArray;
+use block_cipher::{BlockCipher, NewBlockCipher};
 use core::slice;
 use stream_cipher::{InvalidKeyNonceLength, NewStreamCipher, StreamCipher};
 
@@ -66,9 +66,12 @@ pub struct Cfb<C: BlockCipher> {
 
 type Block<C> = GenericArray<u8, <C as BlockCipher>::BlockSize>;
 type ParBlocks<C> = GenericArray<Block<C>, <C as BlockCipher>::ParBlocks>;
-type Key<C> = GenericArray<u8, <C as BlockCipher>::KeySize>;
+type Key<C> = GenericArray<u8, <C as NewBlockCipher>::KeySize>;
 
-impl<C: BlockCipher> NewStreamCipher for Cfb<C> {
+impl<C> NewStreamCipher for Cfb<C>
+where
+    C: BlockCipher + NewBlockCipher,
+{
     type KeySize = C::KeySize;
     type NonceSize = C::BlockSize;
 

--- a/cfb-mode/tests/mod.rs
+++ b/cfb-mode/tests/mod.rs
@@ -1,5 +1,5 @@
-extern crate aes;
-extern crate cfb_mode;
+use aes;
+
 #[macro_use]
 extern crate stream_cipher;
 


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `stream-cipher` v0.4.0-pre crate.