### PR TITLE
cfb8: 2018 edition and `stream-cipher` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,10 +169,10 @@ dependencies = [
 name = "cfb8"
 version = "0.3.2"
 dependencies = [
- "aes 0.3.2",
- "block-cipher-trait",
+ "aes 0.4.0-pre",
+ "block-cipher",
  "hex-literal",
- "stream-cipher 0.3.2",
+ "stream-cipher 0.4.0-pre",
 ]
 
 [[package]]

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -9,14 +9,15 @@ repository = "https://github.com/RustCrypto/stream-ciphers"
 keywords = ["crypto", "stream-cipher", "block-mode"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
-stream-cipher = "0.3"
-block-cipher-trait = "0.6"
+stream-cipher = "= 0.4.0-pre"
+block-cipher = "= 0.7.0-pre"
 
 [dev-dependencies]
-aes = "0.3"
-stream-cipher = { version = "0.3", features = ["dev"] }
+aes = "= 0.4.0-pre"
+stream-cipher = { version = "= 0.4.0-pre", features = ["dev"] }
 hex-literal = "0.1"
 
 [badges]

--- a/cfb8/benches/cfb8.rs
+++ b/cfb8/benches/cfb8.rs
@@ -1,8 +1,8 @@
 #![feature(test)]
 #[macro_use]
 extern crate stream_cipher;
-extern crate aes;
-extern crate cfb8;
+use aes;
+use cfb8;
 
 type Aes128Cfb8 = cfb8::Cfb8<aes::Aes128>;
 

--- a/cfb8/src/lib.rs
+++ b/cfb8/src/lib.rs
@@ -48,12 +48,12 @@
 #![no_std]
 #![deny(missing_docs)]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
-extern crate block_cipher_trait;
-pub extern crate stream_cipher;
 
-use block_cipher_trait::generic_array::typenum::Unsigned;
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::BlockCipher;
+pub use stream_cipher;
+
+use block_cipher::generic_array::typenum::Unsigned;
+use block_cipher::generic_array::GenericArray;
+use block_cipher::{BlockCipher, NewBlockCipher};
 use stream_cipher::{InvalidKeyNonceLength, NewStreamCipher, StreamCipher};
 
 /// CFB self-synchronizing stream cipher instance.
@@ -62,7 +62,10 @@ pub struct Cfb8<C: BlockCipher> {
     iv: GenericArray<u8, C::BlockSize>,
 }
 
-impl<C: BlockCipher> NewStreamCipher for Cfb8<C> {
+impl<C> NewStreamCipher for Cfb8<C>
+where
+    C: BlockCipher + NewBlockCipher,
+{
     type KeySize = C::KeySize;
     type NonceSize = C::BlockSize;
 

--- a/cfb8/tests/mod.rs
+++ b/cfb8/tests/mod.rs
@@ -1,5 +1,5 @@
-extern crate aes;
-extern crate cfb8;
+use aes;
+
 #[macro_use]
 extern crate stream_cipher;
 


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `stream-cipher` v0.4.0-pre crate.