### PR TITLE
chacha20: `stream-cipher` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
  "criterion",
  "criterion-cycles-per-byte",
  "rand_core",
- "stream-cipher 0.3.2",
+ "stream-cipher 0.4.0-pre",
  "zeroize",
 ]
 

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -21,11 +21,11 @@ travis-ci = { repository = "RustCrypto/stream-ciphers" }
 
 [dependencies]
 rand_core = { version = "0.5", optional = true, default-features = false }
-stream-cipher = { version = "0.3", optional = true }
+stream-cipher = { version = "= 0.4.0-pre", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-stream-cipher = { version = "0.3", features = ["dev"] }
+stream-cipher = { version = "= 0.4.0-pre", features = ["dev"] }
 criterion = "0.3"
 criterion-cycles-per-byte = "0.1"
 

--- a/chacha20/src/cipher.rs
+++ b/chacha20/src/cipher.rs
@@ -72,7 +72,7 @@ impl<R: Rounds> NewStreamCipher for Cipher<R> {
 
     fn new(key: &GenericArray<u8, U32>, iv: &GenericArray<u8, U12>) -> Self {
         let block = Block::new(
-            key.as_ref().try_into().unwrap(),
+            key.as_slice().try_into().unwrap(),
             iv[4..12].try_into().unwrap(),
         );
 


### PR DESCRIPTION
Upgrades to the `stream-cipher` v0.4.0-pre crate.