### PR TITLE
hc-256: 2018 edition and `stream-cipher` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ name = "block-cipher"
 version = "0.7.0-pre"
 source = "git+https://github.com/RustCrypto/traits#8f24286f0aa22d9f98a3edbe859a890d5d0d879e"
 dependencies = [
+ "blobby",
  "generic-array 0.14.1",
 ]
 
@@ -118,7 +119,6 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 dependencies = [
- "blobby",
  "generic-array 0.12.3",
 ]
 
@@ -354,8 +354,8 @@ dependencies = [
 name = "hc-256"
 version = "0.0.1"
 dependencies = [
- "block-cipher-trait",
- "stream-cipher 0.3.2",
+ "block-cipher",
+ "stream-cipher 0.4.0-pre",
  "zeroize",
 ]
 

--- a/hc-256/Cargo.toml
+++ b/hc-256/Cargo.toml
@@ -8,15 +8,16 @@ repository = "https://github.com/RustCrypto/stream-ciphers"
 keywords = ["crypto", "stream-cipher", "trait"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
-block-cipher-trait = "0.6"
-stream-cipher = "0.3"
+block-cipher = "= 0.7.0-pre"
+stream-cipher = "= 0.4.0-pre"
 zeroize = { version = "1", optional = true }
 
 [dev-dependencies]
-stream-cipher = { version = "0.3", features = ["dev"] }
-block-cipher-trait = { version = "0.6", features = ["dev"] }
+stream-cipher = { version = "= 0.4.0-pre", features = ["dev"] }
+block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/hc-256/src/lib.rs
+++ b/hc-256/src/lib.rs
@@ -1,15 +1,12 @@
+//! HC-256 Stream Cipher
+
 #![no_std]
-extern crate block_cipher_trait;
 
-#[cfg(cargo_feature = "zeroize")]
-extern crate zeroize;
+pub use stream_cipher;
 
-pub extern crate stream_cipher;
-
-use block_cipher_trait::generic_array::typenum::U32;
-use block_cipher_trait::generic_array::GenericArray;
-use stream_cipher::NewStreamCipher;
-use stream_cipher::StreamCipher;
+use block_cipher::consts::U32;
+use block_cipher::generic_array::GenericArray;
+use stream_cipher::{NewStreamCipher, StreamCipher};
 
 #[cfg(cargo_feature = "zeroize")]
 use std::ops::Drop;
@@ -17,19 +14,14 @@ use std::ops::Drop;
 use zeroize::Zeroize;
 
 const TABLE_SIZE: usize = 1024;
-
 const TABLE_MASK: usize = TABLE_SIZE - 1;
-
 const INIT_SIZE: usize = 2660;
-
 const KEY_BITS: usize = 256;
-
 const KEY_WORDS: usize = KEY_BITS / 32;
-
 const IV_BITS: usize = 256;
-
 const IV_WORDS: usize = IV_BITS / 32;
 
+/// The HC-256 stream cipher
 pub struct HC256 {
     ptable: [u32; TABLE_SIZE],
     qtable: [u32; TABLE_SIZE],

--- a/hc-256/tests/mod.rs
+++ b/hc-256/tests/mod.rs
@@ -1,8 +1,4 @@
-extern crate block_cipher_trait;
-extern crate hc_256;
-extern crate stream_cipher;
-
-use block_cipher_trait::generic_array::GenericArray;
+use block_cipher::generic_array::GenericArray;
 use hc_256::HC256;
 use stream_cipher::NewStreamCipher;
 use stream_cipher::StreamCipher;


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `stream-cipher` v0.4.0-pre crate.