### PR TITLE
salsa20: 2018 edition idioms and `stream-cipher` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
  "aes-soft",
  "aesni",
  "ctr",
- "stream-cipher 0.4.0-pre",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -37,7 +37,7 @@ source = "git+https://github.com/RustCrypto/block-ciphers#044bc4ce9c0634871790cf
 dependencies = [
  "block-cipher",
  "opaque-debug",
- "stream-cipher 0.4.0-pre",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -78,7 +78,7 @@ version = "0.7.0-pre"
 source = "git+https://github.com/RustCrypto/traits#8f24286f0aa22d9f98a3edbe859a890d5d0d879e"
 dependencies = [
  "blobby",
- "generic-array 0.14.1",
+ "generic-array",
 ]
 
 [[package]]
@@ -121,7 +121,7 @@ dependencies = [
  "aes",
  "block-cipher",
  "hex-literal",
- "stream-cipher 0.4.0-pre",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -131,7 +131,7 @@ dependencies = [
  "aes",
  "block-cipher",
  "hex-literal",
- "stream-cipher 0.4.0-pre",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -147,7 +147,7 @@ dependencies = [
  "criterion",
  "criterion-cycles-per-byte",
  "rand_core",
- "stream-cipher 0.4.0-pre",
+ "stream-cipher",
  "zeroize",
 ]
 
@@ -282,7 +282,7 @@ dependencies = [
  "aes",
  "blobby",
  "block-cipher",
- "stream-cipher 0.4.0-pre",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -290,15 +290,6 @@ name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
-
-[[package]]
-name = "generic-array"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "generic-array"
@@ -314,7 +305,7 @@ name = "hc-256"
 version = "0.0.1"
 dependencies = [
  "block-cipher",
- "stream-cipher 0.4.0-pre",
+ "stream-cipher",
  "zeroize",
 ]
 
@@ -438,7 +429,7 @@ dependencies = [
  "aes",
  "block-cipher",
  "hex-literal",
- "stream-cipher 0.4.0-pre",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -571,7 +562,7 @@ checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 name = "salsa20"
 version = "0.4.1"
 dependencies = [
- "stream-cipher 0.3.2",
+ "stream-cipher",
  "zeroize",
 ]
 
@@ -635,21 +626,11 @@ dependencies = [
 
 [[package]]
 name = "stream-cipher"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
-dependencies = [
- "blobby",
- "generic-array 0.12.3",
-]
-
-[[package]]
-name = "stream-cipher"
 version = "0.4.0-pre"
 source = "git+https://github.com/RustCrypto/traits#8f24286f0aa22d9f98a3edbe859a890d5d0d879e"
 dependencies = [
  "blobby",
- "generic-array 0.14.1",
+ "generic-array",
 ]
 
 [[package]]

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = "0.3"
+stream-cipher = "= 0.4.0-pre"
 zeroize = { version = "1", optional = true }
 
 [dev-dependencies]
-stream-cipher = { version = "0.3", features = ["dev"] }
+stream-cipher = { version = "= 0.4.0-pre", features = ["dev"] }
 
 [features]
 default = ["xsalsa20"]

--- a/salsa20/benches/salsa20.rs
+++ b/salsa20/benches/salsa20.rs
@@ -1,6 +1,4 @@
 #![feature(test)]
-#[macro_use]
-extern crate stream_cipher;
-extern crate salsa20;
 
+use stream_cipher::bench_sync;
 bench_sync!(salsa20::Salsa20);

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -83,7 +83,7 @@ impl NewStreamCipher for Salsa20 {
     type NonceSize = U8;
 
     fn new(key: &GenericArray<u8, Self::KeySize>, iv: &GenericArray<u8, Self::NonceSize>) -> Self {
-        let block = Block::new(key.as_ref().try_into().unwrap(), (*iv).into());
+        let block = Block::new(key.as_slice().try_into().unwrap(), (*iv).into());
 
         Salsa20(Cipher::new(block))
     }

--- a/salsa20/tests/lib.rs
+++ b/salsa20/tests/lib.rs
@@ -1,8 +1,5 @@
 //! Salsa20 tests
 
-extern crate salsa20;
-extern crate stream_cipher;
-
 use salsa20::Salsa20;
 #[cfg(feature = "xsalsa20")]
 use salsa20::XSalsa20;


### PR DESCRIPTION
Upgrades to Rust 2018 edition idioms and the (now 2018 edition) `stream-cipher` v0.4.0-pre crate.