### PR TITLE
Bump `hex-literal` crate to v0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "hex-literal"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc2928beef125e519d69ae1baa8c37ea2e0d3848545217f6db0179c5eb1d639"
+checksum = "961de220ec9a91af2e1e5bd80d02109155695e516771762381ef8581317066e0"
 dependencies = [
  "hex-literal-impl",
  "proc-macro-hack",
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "hex-literal-impl"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520870c3213943eb8d7803e80180d12a6c7ceb4ae74602544529d1643dc4ddda"
+checksum = "9d4c5c844e2fee0bf673d54c2c177f1713b3d2af2ff6e666b49cb7572e6cf42d"
 dependencies = [
  "proc-macro-hack",
 ]
@@ -458,18 +458,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.4.2"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463bf29e7f11344e58c9e01f171470ab15c925c6822ad75028cc1c0e1d1eb63b"
-dependencies = [
- "proc-macro-hack-impl",
-]
-
-[[package]]
-name = "proc-macro-hack-impl"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c47dcb1594802de8c02f3b899e2018c78291168a22c281be21ea0fb4796842"
+checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro2"

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -18,7 +18,7 @@ block-cipher = "= 0.7.0-pre"
 [dev-dependencies]
 aes = "= 0.4.0-pre"
 stream-cipher = { version = "= 0.4.0-pre", features = ["dev"] }
-hex-literal = "0.1"
+hex-literal = "0.2"
 
 [badges]
 travis-ci = { repository = "RustCrypto/stream-ciphers" }

--- a/cfb-mode/src/lib.rs
+++ b/cfb-mode/src/lib.rs
@@ -8,11 +8,10 @@
 //!
 //! # Examples
 //! ```
-//! #[macro_use] extern crate hex_literal;
-//!
 //! use aes::Aes128;
 //! use cfb_mode::Cfb;
 //! use cfb_mode::stream_cipher::{NewStreamCipher, StreamCipher};
+//! use hex_literal::hex;
 //!
 //! type AesCfb = Cfb<Aes128>;
 //!

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -18,7 +18,7 @@ block-cipher = "= 0.7.0-pre"
 [dev-dependencies]
 aes = "= 0.4.0-pre"
 stream-cipher = { version = "= 0.4.0-pre", features = ["dev"] }
-hex-literal = "0.1"
+hex-literal = "0.2"
 
 [badges]
 travis-ci = { repository = "RustCrypto/stream-ciphers" }

--- a/cfb8/src/lib.rs
+++ b/cfb8/src/lib.rs
@@ -8,11 +8,10 @@
 //!
 //! # Examples
 //! ```
-//! #[macro_use] extern crate hex_literal;
-//!
 //! use aes::Aes128;
 //! use cfb8::Cfb8;
 //! use cfb8::stream_cipher::{NewStreamCipher, StreamCipher};
+//! use hex_literal::hex;
 //!
 //! type AesCfb8 = Cfb8<Aes128>;
 //!

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -18,7 +18,7 @@ block-cipher = "= 0.7.0-pre"
 [dev-dependencies]
 aes = "= 0.4.0-pre"
 stream-cipher = { version = "= 0.4.0-pre", features = ["dev"] }
-hex-literal = "0.1"
+hex-literal = "0.2"
 
 [badges]
 travis-ci = { repository = "RustCrypto/stream-ciphers" }

--- a/ofb/src/lib.rs
+++ b/ofb/src/lib.rs
@@ -8,9 +8,8 @@
 //!
 //! # Examples
 //! ```
-//! #[macro_use] extern crate hex_literal;
-//!
 //! use aes::Aes128;
+//! use hex_literal::hex;
 //! use ofb::Ofb;
 //! use ofb::stream_cipher::{NewStreamCipher, SyncStreamCipher};
 //!


### PR DESCRIPTION
This version is a 2018 edition crate and allows us to get rid of the last remaining usages of "extern crate" in the repo! 🎉