### PR TITLE
Bump all versions to `*-pre`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "aes-ctr"
-version = "0.3.0"
+version = "0.4.0-pre"
 dependencies = [
  "aes-soft",
  "aesni",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "cfb-mode"
-version = "0.3.2"
+version = "0.4.0-pre"
 dependencies = [
  "aes",
  "block-cipher",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "cfb8"
-version = "0.3.2"
+version = "0.4.0-pre"
 dependencies = [
  "aes",
  "block-cipher",
@@ -142,7 +142,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chacha20"
-version = "0.3.4"
+version = "0.4.0-pre"
 dependencies = [
  "criterion",
  "criterion-cycles-per-byte",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.3.2"
+version = "0.4.0-pre"
 dependencies = [
  "aes",
  "blobby",
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "hc-256"
-version = "0.0.1"
+version = "0.1.0-pre"
 dependencies = [
  "block-cipher",
  "stream-cipher",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "ofb"
-version = "0.1.1"
+version = "0.2.0-pre"
 dependencies = [
  "aes",
  "block-cipher",
@@ -551,7 +551,7 @@ checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
 name = "salsa20"
-version = "0.4.1"
+version = "0.5.0-pre"
 dependencies = [
  "stream-cipher",
  "zeroize",

--- a/aes-ctr/Cargo.toml
+++ b/aes-ctr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-ctr"
-version = "0.3.0"
+version = "0.4.0-pre"
 description = "AES-CTR stream ciphers"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ edition = "2018"
 stream-cipher = "= 0.4.0-pre"
 
 [target.'cfg(not(all(target_feature = "aes", target_feature = "sse2", target_feature = "ssse3", any(target_arch = "x86_64", target_arch = "x86"))))'.dependencies]
-ctr = { version = "0.3", path = "../ctr" }
+ctr = { version = "= 0.4.0-pre", path = "../ctr" }
 aes-soft = "= 0.4.0-pre"
 
 [target.'cfg(all(target_feature = "aes", target_feature = "sse2", target_feature = "ssse3", any(target_arch = "x86_64", target_arch = "x86")))'.dependencies]

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfb-mode"
-version = "0.3.2"
+version = "0.4.0-pre"
 description = "Generic Cipher Feedback (CFB) mode implementation."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfb8"
-version = "0.3.2"
+version = "0.4.0-pre"
 description = "Generic 8-bit Cipher Feedback (CFB8) mode implementation."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.3.4"
+version = "0.4.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctr"
-version = "0.3.2"
+version = "0.4.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "CTR block mode of operation"

--- a/hc-256/Cargo.toml
+++ b/hc-256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hc-256"
-version = "0.0.1"
+version = "0.1.0-pre"
 authors = ["Eric McCorkle <eric@metricspace.net>"]
 license = "MIT OR Apache-2.0"
 description = "HC-256 Stream Cipher"

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ofb"
-version = "0.1.1"
+version = "0.2.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic Output Feedback (OFB) mode implementation."

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa20"
-version = "0.4.1"
+version = "0.5.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Salsa20 Stream Cipher"


### PR DESCRIPTION
...to reflect the breaking `stream-cipher` crate update