### PR TITLE
salsa20: add Salsa8 and Salsa12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,4 +783,3 @@ name = "zeroize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
-

--- a/salsa20/src/rounds.rs
+++ b/salsa20/src/rounds.rs
@@ -1,0 +1,29 @@
+//! Numbers of rounds allowed to be used with a Salsa20 family stream cipher
+
+pub trait Rounds: Copy {
+    const COUNT: usize;
+}
+
+/// 8-rounds (Salsa20/8)
+#[derive(Copy, Clone)]
+pub struct R8;
+
+impl Rounds for R8 {
+    const COUNT: usize = 8;
+}
+
+/// 12-rounds (Salsa20/12)
+#[derive(Copy, Clone)]
+pub struct R12;
+
+impl Rounds for R12 {
+    const COUNT: usize = 12;
+}
+
+/// 20-rounds (Salsa20/20)
+#[derive(Copy, Clone)]
+pub struct R20;
+
+impl Rounds for R20 {
+    const COUNT: usize = 20;
+}


### PR DESCRIPTION
This adds a generic parameter to `Cipher` and `Block` ala the `chacha20` crate which makes them generic over a number of rounds (using a sealed `Rounds` trait which is explicitly impl'd for `R8`, `R12`, and `R20`).

This is used to provide `Salsa8`, `Salsa12`, and `Salsa20` variants.

The main impetus for this is using `Salsa8` to implement `scrypt`. We could potentially replace the vendored implementation here:

<https://github.com/RustCrypto/password-hashing/blob/master/scrypt/src/romix.rs>