### PR TITLE
README.md(s): fix typo

### DIFF
--- a/aes-ctr/README.md
+++ b/aes-ctr/README.md
@@ -19,7 +19,7 @@ implementation and the [`ctr`][3] crate.
 ### ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 To avoid this, use an [AEAD][4] mode based on AES, such as [AES-GCM][5] or

--- a/cfb-mode/README.md
+++ b/cfb-mode/README.md
@@ -17,7 +17,7 @@ Generic [Cipher Feedback (CFB)][1] mode implementation as a
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 No security audits of this crate have ever been performed, and it has not been

--- a/cfb8/README.md
+++ b/cfb8/README.md
@@ -15,7 +15,7 @@ Generic [8-bit Cipher Feedback (CFB8)][1] mode implementation as a
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 No security audits of this crate have ever been performed, and it has not been

--- a/ctr/README.md
+++ b/ctr/README.md
@@ -17,7 +17,7 @@ a 128-bit block size.
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 No security audits of this crate have ever been performed, and it has not been

--- a/hc-256/README.md
+++ b/hc-256/README.md
@@ -14,7 +14,7 @@ Pure Rust implementation of the [HC-256 Stream Cipher][1].
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 No security audits of this crate have ever been performed, and it has not been

--- a/ofb/README.md
+++ b/ofb/README.md
@@ -17,7 +17,7 @@ Generic [Output Feedback (OFB)][1] mode implementation as a
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 No security audits of this crate have ever been performed, and it has not been

--- a/salsa20/README.md
+++ b/salsa20/README.md
@@ -25,7 +25,7 @@ of Salsa20 with an extended 192-bit (24-byte) nonce, gated under the
 ## ⚠️ Security Warning: [Hazmat!][hazmat-link]
 
 This crate does not ensure ciphertexts are authentic (i.e. by using a MAC to
-verify ciphertext integerity), which can lead to serious vulnerabilities
+verify ciphertext integrity), which can lead to serious vulnerabilities
 if used incorrectly!
 
 No security audits of this crate have ever been performed, and it has not been


### PR DESCRIPTION
Spelling error: "integerity" -> "integrity"