### PR TITLE
Use release versions of crate dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,8 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aes"
-version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers#f2d2e41f1cec0e64f6dff15baec2b54d37d813a3"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
 dependencies = [
  "aes-soft",
  "aesni",
@@ -22,8 +23,9 @@ dependencies = [
 
 [[package]]
 name = "aes-soft"
-version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers#f2d2e41f1cec0e64f6dff15baec2b54d37d813a3"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
 dependencies = [
  "block-cipher",
  "byteorder",
@@ -32,8 +34,9 @@ dependencies = [
 
 [[package]]
 name = "aesni"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers#f2d2e41f1cec0e64f6dff15baec2b54d37d813a3"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
 dependencies = [
  "block-cipher",
  "opaque-debug",
@@ -74,8 +77,9 @@ dependencies = [
 
 [[package]]
 name = "block-cipher"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/traits#c2266385dc366383baaf5699b727a27c62d3f446"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f837aab23b44bf3be7e24411b599fda76b1788792e765fa077af268292e156d1"
 dependencies = [
  "blobby",
  "generic-array",
@@ -616,8 +620,9 @@ dependencies = [
 
 [[package]]
 name = "stream-cipher"
-version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/traits#c2266385dc366383baaf5699b727a27c62d3f446"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97961116ec5528e0df39aa6e514377cd1572b8b4623576b371da425a87328d16"
 dependencies = [
  "blobby",
  "block-cipher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,3 @@ members = [
     "ofb",
     "salsa20",
 ]
-
-[patch.crates-io]
-aes = { git = "https://github.com/RustCrypto/block-ciphers" }
-aesni = { git = "https://github.com/RustCrypto/block-ciphers" }
-aes-soft = { git = "https://github.com/RustCrypto/block-ciphers" }
-block-cipher = { git = "https://github.com/RustCrypto/traits" }
-stream-cipher = { git = "https://github.com/RustCrypto/traits" }

--- a/aes-ctr/Cargo.toml
+++ b/aes-ctr/Cargo.toml
@@ -12,14 +12,14 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = "= 0.4.0-pre"
+stream-cipher = "0.4"
 
 [target.'cfg(not(all(target_feature = "aes", target_feature = "sse2", target_feature = "ssse3", any(target_arch = "x86_64", target_arch = "x86"))))'.dependencies]
 ctr = { version = "= 0.4.0-pre", path = "../ctr" }
-aes-soft = "= 0.4.0-pre"
+aes-soft = "0.4"
 
 [target.'cfg(all(target_feature = "aes", target_feature = "sse2", target_feature = "ssse3", any(target_arch = "x86_64", target_arch = "x86")))'.dependencies]
-aesni = "= 0.7.0-pre"
+aesni = "0.7"
 
 [dev-dependencies]
-stream-cipher = { version = "= 0.4.0-pre", features = ["dev"] }
+stream-cipher = { version = "0.4", features = ["dev"] }

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -12,10 +12,10 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = "= 0.4.0-pre"
-block-cipher = "= 0.7.0-pre"
+stream-cipher = "0.4"
+block-cipher = "0.7"
 
 [dev-dependencies]
-aes = "= 0.4.0-pre"
-stream-cipher = { version = "= 0.4.0-pre", features = ["dev"] }
+aes = "0.4"
+stream-cipher = { version = "0.4", features = ["dev"] }
 hex-literal = "0.2"

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -12,10 +12,10 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = "= 0.4.0-pre"
-block-cipher = "= 0.7.0-pre"
+stream-cipher = "0.4"
+block-cipher = "0.7"
 
 [dev-dependencies]
-aes = "= 0.4.0-pre"
-stream-cipher = { version = "= 0.4.0-pre", features = ["dev"] }
+aes = "0.4"
+stream-cipher = { version = "0.4", features = ["dev"] }
 hex-literal = "0.2"

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -18,11 +18,11 @@ edition = "2018"
 
 [dependencies]
 rand_core = { version = "0.5", optional = true, default-features = false }
-stream-cipher = { version = "= 0.4.0-pre", optional = true }
+stream-cipher = { version = "0.4", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-stream-cipher = { version = "= 0.4.0-pre", features = ["dev"] }
+stream-cipher = { version = "0.4", features = ["dev"] }
 criterion = "0.3"
 criterion-cycles-per-byte = "0.1"
 

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = { version = "= 0.4.0-pre", features = ["block-cipher"] }
+stream-cipher = { version = "0.4", features = ["block-cipher"] }
 
 [dev-dependencies]
-aes = "= 0.4.0-pre"
-stream-cipher = { version = "= 0.4.0-pre", features = ["dev"] }
+aes = "0.4"
+stream-cipher = { version = "0.4", features = ["dev"] }
 blobby = "0.1"

--- a/hc-256/Cargo.toml
+++ b/hc-256/Cargo.toml
@@ -11,10 +11,10 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-block-cipher = "= 0.7.0-pre"
-stream-cipher = "= 0.4.0-pre"
+block-cipher = "0.7"
+stream-cipher = "0.4"
 zeroize = { version = "1", optional = true }
 
 [dev-dependencies]
-stream-cipher = { version = "= 0.4.0-pre", features = ["dev"] }
-block-cipher = { version = "= 0.7.0-pre", features = ["dev"] }
+stream-cipher = { version = "0.4", features = ["dev"] }
+block-cipher = { version = "0.7", features = ["dev"] }

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -12,10 +12,10 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = "= 0.4.0-pre"
-block-cipher = "= 0.7.0-pre"
+stream-cipher = "0.4"
+block-cipher = "= 0.7"
 
 [dev-dependencies]
-aes = "= 0.4.0-pre"
-stream-cipher = { version = "= 0.4.0-pre", features = ["dev"] }
+aes = "0.4"
+stream-cipher = { version = "0.4", features = ["dev"] }
 hex-literal = "0.2"

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = "= 0.4.0-pre"
+stream-cipher = "0.4"
 zeroize = { version = "1", optional = true }
 
 [dev-dependencies]
-stream-cipher = { version = "= 0.4.0-pre", features = ["dev"] }
+stream-cipher = { version = "0.4", features = ["dev"] }
 
 [features]
 default = ["xsalsa20"]


### PR DESCRIPTION
Updates the following dependencies to use crates.io releases:

- `aes` v0.4.0
- `aes-soft` v0.4.0
- `aesni` v0.7.0
- `block-cipher` v0.7.0
- `stream-cipher` v0.4.0