### PR TITLE
ctr v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "aes",
  "blobby",

--- a/aes-ctr/Cargo.toml
+++ b/aes-ctr/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 stream-cipher = "0.4"
 
 [target.'cfg(not(all(target_feature = "aes", target_feature = "sse2", target_feature = "ssse3", any(target_arch = "x86_64", target_arch = "x86"))))'.dependencies]
-ctr = { version = "= 0.4.0-pre", path = "../ctr" }
+ctr = { version = "0.4", path = "../ctr" }
 aes-soft = "0.4"
 
 [target.'cfg(all(target_feature = "aes", target_feature = "sse2", target_feature = "ssse3", any(target_arch = "x86_64", target_arch = "x86")))'.dependencies]

--- a/ctr/CHANGELOG.md
+++ b/ctr/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.4.0 (2020-06-06)
+### Changed
+- Upgrade to the `stream-cipher` v0.4 crate ([#116], [#138])
+- Upgrade to Rust 2018 edition ([#116])
+
+[#138]: https://github.com/RustCrypto/stream-ciphers/pull/138
+[#116]: https://github.com/RustCrypto/stream-ciphers/pull/121
+
+## 0.3.2 (2019-03-11)
+
+## 0.3.0 (2018-11-01)
+
+## 0.2.0 (2018-10-13)
+
+## 0.1.1 (2018-10-13)
+
+## 0.1.0 (2018-07-30)

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctr"
-version = "0.4.0-pre"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "CTR block mode of operation"


### PR DESCRIPTION
### Changed
- Upgrade to the `stream-cipher` v0.4 crate ([#116], [#138])
- Upgrade to Rust 2018 edition ([#116])

[#138]: https://github.com/RustCrypto/stream-ciphers/pull/138
[#116]: https://github.com/RustCrypto/stream-ciphers/pull/121