### PR TITLE
.github: label chacha20 test steps

### DIFF
--- a/.github/workflows/chacha20.yml
+++ b/.github/workflows/chacha20.yml
@@ -69,11 +69,12 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo test
       - run: cargo test --release
-      - run: cargo test --release
+      - name: "Run cargo test --release (SSE2)"
         env:
           RUSTFLAGS: "-Ctarget-feature=+sse2 -Dwarnings"
-      - run: cargo test --release
+        run: cargo test --release
+      - name: "Run cargo test --release (AVX2)"
         env:
           RUSTFLAGS: "-Ctarget-feature=+avx2 -Dwarnings"
+        run: cargo test --release


### PR DESCRIPTION
Without this it appears to run `cargo test --release` three times in a row.

This changes it to label the steps which test each of the various backends (portable, SSE2, AVX2).