### PR TITLE
Release new crates after 2018 edition / stream-cipher v0.4 upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aes-ctr"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "aes-soft",
  "aesni",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "cfb-mode"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "aes",
  "block-cipher",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "cfb8"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "aes",
  "block-cipher",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "hc-256"
-version = "0.1.0-pre"
+version = "0.1.0"
 dependencies = [
  "block-cipher",
  "stream-cipher",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "ofb"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "aes",
  "block-cipher",

--- a/aes-ctr/CHANGELOG.md
+++ b/aes-ctr/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.4.0 (2020-06-08)
+### Changed
+- Bump `aesni` dependency to v0.7 ([#138])
+- Bump `ctr` dependency to v0.4 ([#140])
+- Bump `stream-cipher` dependency to v0.4 ([#118])
+- Upgrade to Rust 2018 edition ([#118])
+
+[#140]: https://github.com/RustCrypto/stream-ciphers/pull/140
+[#138]: https://github.com/RustCrypto/stream-ciphers/pull/138
+[#118]: https://github.com/RustCrypto/stream-ciphers/pull/118
+
+## 0.3.0 (2018-11-01)
+
+## 0.2.0 (2018-10-15)
+
+## 0.1.0 (2018-07-30)

--- a/aes-ctr/Cargo.toml
+++ b/aes-ctr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-ctr"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = "AES-CTR stream ciphers"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cfb-mode/CHANGELOG.md
+++ b/cfb-mode/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.4.0 (2020-06-08)
+### Changed
+- Bump `stream-cipher` dependency to v0.4 ([#119])
+- Upgrade to Rust 2018 edition ([#119])
+
+[#119]: https://github.com/RustCrypto/stream-ciphers/pull/119
+
+## 0.3.2 (2019-03-11)
+
+## 0.3.1 (2018-11-01)
+
+## 0.3.0 (2018-11-01)
+
+## 0.2.0 (2018-10-13)
+
+## 0.1.0 (2018-10-01)

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfb-mode"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = "Generic Cipher Feedback (CFB) mode implementation."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cfb8/CHANGELOG.md
+++ b/cfb8/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.4.0 (2020-06-08)
+### Changed
+- Bump `stream-cipher` dependency to v0.4 ([#120])
+- Upgrade to Rust 2018 edition ([#120])
+
+[#120]: https://github.com/RustCrypto/stream-ciphers/pull/120
+
+## 0.3.2 (2019-03-11)
+
+## 0.3.1 (2018-11-01)
+
+## 0.3.0 (2018-11-01)
+
+## 0.1.0 (2018-11-01)

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfb8"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = "Generic 8-bit Cipher Feedback (CFB8) mode implementation."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/hc-256/CHANGELOG.md
+++ b/hc-256/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.1.0 (2020-06-08)
+### Changed
+- Bump `stream-cipher` dependency to v0.4 ([#122])
+- Upgrade to Rust 2018 edition ([#122])
+
+[#122]: https://github.com/RustCrypto/stream-ciphers/pull/122
+
+## 0.0.1 (2019-10-02)
+- Initial release

--- a/hc-256/Cargo.toml
+++ b/hc-256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hc-256"
-version = "0.1.0-pre"
+version = "0.1.0"
 authors = ["Eric McCorkle <eric@metricspace.net>"]
 license = "MIT OR Apache-2.0"
 description = "HC-256 Stream Cipher"

--- a/ofb/CHANGELOG.md
+++ b/ofb/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0 (2020-06-08)
+### Changed
+- Bump `stream-cipher` dependency to v0.4 ([#123])
+- Upgrade to Rust 2018 edition ([#123])
+
+[#123]: https://github.com/RustCrypto/stream-ciphers/pull/123
+
+## 0.1.1 (2019-03-11)
+
+## 0.1.0 (2018-12-26)

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ofb"
-version = "0.2.0-pre"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic Output Feedback (OFB) mode implementation."


### PR DESCRIPTION
This commit cuts releases of the following crates:

- `aes-ctr` v0.4.0
- `cfb8` v0.4.0
- `cfb-mode` v0.4.0
- `hc-256` v0.1.0
- `ofb` v0.2.0