### PR TITLE
salsa20: use stream_cipher::{Key, Nonce}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,8 +78,7 @@ dependencies = [
 [[package]]
 name = "block-cipher"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f837aab23b44bf3be7e24411b599fda76b1788792e765fa077af268292e156d1"
+source = "git+https://github.com/RustCrypto/traits#00fd43d39d94705af6a83409aa943ff2e7acab07"
 dependencies = [
  "blobby",
  "generic-array",
@@ -621,8 +620,7 @@ dependencies = [
 [[package]]
 name = "stream-cipher"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97961116ec5528e0df39aa6e514377cd1572b8b4623576b371da425a87328d16"
+source = "git+https://github.com/RustCrypto/traits#00fd43d39d94705af6a83409aa943ff2e7acab07"
 dependencies = [
  "blobby",
  "block-cipher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ members = [
     "ofb",
     "salsa20",
 ]
+
+[patch.crates-io]
+block-cipher = { git = "https://github.com/RustCrypto/traits" }
+stream-cipher = { git = "https://github.com/RustCrypto/traits" }

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -47,7 +47,7 @@ mod rounds;
 mod xsalsa20;
 
 #[cfg(feature = "xsalsa20")]
-pub use self::xsalsa20::XSalsa20;
+pub use self::xsalsa20::{XNonce, XSalsa20};
 
 #[cfg(feature = "hsalsa20")]
 pub use self::xsalsa20::hsalsa20;
@@ -58,8 +58,7 @@ use crate::{
     rounds::{Rounds, R12, R20, R8},
 };
 use core::convert::TryInto;
-use stream_cipher::generic_array::typenum::{U32, U8};
-use stream_cipher::generic_array::GenericArray;
+use stream_cipher::consts::{U32, U8};
 use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
 
 /// Size of a Salsa20 block in bytes
@@ -89,6 +88,14 @@ pub type Salsa12 = Salsa<R12>;
 /// (20 rounds; **recommended**)
 pub type Salsa20 = Salsa<R20>;
 
+/// Key type.
+///
+/// NOTE: all three round variants use the same key size.
+pub type Key = stream_cipher::Key<Salsa20>;
+
+/// Nonce type
+pub type Nonce = stream_cipher::Nonce<Salsa20>;
+
 /// The Salsa20 family of stream ciphers
 /// (implemented generically over a number of rounds).
 ///
@@ -103,8 +110,8 @@ impl<R: Rounds> NewStreamCipher for Salsa<R> {
     /// Nonce size in bytes
     type NonceSize = U8;
 
-    fn new(key: &GenericArray<u8, Self::KeySize>, iv: &GenericArray<u8, Self::NonceSize>) -> Self {
-        let block = Block::new(key.as_slice().try_into().unwrap(), (*iv).into());
+    fn new(key: &Key, nonce: &Nonce) -> Self {
+        let block = Block::new(key.as_slice().try_into().unwrap(), (*nonce).into());
         Salsa(Cipher::new(block))
     }
 }


### PR DESCRIPTION
Introduced in this PR:

https://github.com/RustCrypto/traits/pull/188

These eliminate the need to import `GenericArray`! 🎉