### PR TITLE
chacha20: use stream_cipher::{Key, Nonce} type aliases

### DIFF
--- a/chacha20/src/legacy.rs
+++ b/chacha20/src/legacy.rs
@@ -1,11 +1,11 @@
 //! Legacy version of ChaCha20 with a 64-bit nonce
 
-use crate::cipher::ChaCha20;
-use stream_cipher::generic_array::{
-    typenum::{U32, U8},
-    GenericArray,
-};
+use crate::cipher::{ChaCha20, Key};
+use stream_cipher::consts::{U32, U8};
 use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
+
+/// Size of the nonce for the legacy ChaCha20 stream cipher
+pub type LegacyNonce = stream_cipher::Nonce<ChaCha20Legacy>;
 
 /// The ChaCha20 stream cipher (legacy "djb" construction with 64-bit nonce).
 ///
@@ -19,10 +19,10 @@ impl NewStreamCipher for ChaCha20Legacy {
     /// Nonce size in bytes
     type NonceSize = U8;
 
-    fn new(key: &GenericArray<u8, Self::KeySize>, iv: &GenericArray<u8, Self::NonceSize>) -> Self {
-        let mut exp_iv = GenericArray::default();
-        exp_iv[4..].copy_from_slice(iv);
-        ChaCha20Legacy(ChaCha20::new(key, &exp_iv))
+    fn new(key: &Key, nonce: &LegacyNonce) -> Self {
+        let mut exp_iv = [0u8; 12];
+        exp_iv[4..].copy_from_slice(nonce);
+        ChaCha20Legacy(ChaCha20::new(key, &exp_iv.into()))
     }
 }
 

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -70,10 +70,10 @@ mod xchacha20;
 mod rng;
 
 #[cfg(feature = "stream-cipher")]
-pub use self::cipher::{ChaCha12, ChaCha20, ChaCha8, Cipher};
+pub use self::cipher::{ChaCha12, ChaCha20, ChaCha8, Cipher, Key, Nonce};
 
 #[cfg(feature = "legacy")]
-pub use self::legacy::ChaCha20Legacy;
+pub use self::legacy::{ChaCha20Legacy, LegacyNonce};
 
 #[cfg(feature = "rng")]
 pub use rng::{
@@ -81,7 +81,7 @@ pub use rng::{
 };
 
 #[cfg(feature = "xchacha20")]
-pub use self::xchacha20::XChaCha20;
+pub use self::xchacha20::{XChaCha20, XNonce};
 
 /// Size of a ChaCha20 block in bytes
 pub const BLOCK_SIZE: usize = 64;

--- a/chacha20/tests/lib.rs
+++ b/chacha20/tests/lib.rs
@@ -9,8 +9,8 @@ new_seek_test!(chacha20_seek, ChaCha20, "chacha20");
 
 #[cfg(features = "xchacha20")]
 mod xchacha20 {
-    use chacha20::XChaCha20;
-    use stream_cipher::{generic_array::GenericArray, NewStreamCipher, StreamCipher};
+    use chacha20::{Key, XChaCha20, XNonce};
+    use stream_cipher::{NewStreamCipher, StreamCipher};
 
     //
     // XChaCha20 test vectors from:
@@ -102,7 +102,7 @@ mod xchacha20 {
 
     #[test]
     fn xchacha20_keystream() {
-        let mut cipher = XChaCha20::new(&GenericArray::from(KEY), &GenericArray::from(IV));
+        let mut cipher = XChaCha20::new(&Key::from(KEY), &XNonce::from(IV));
 
         // The test vectors omit the first 64-bytes of the keystream
         let mut prefix = [0u8; 64];
@@ -115,7 +115,7 @@ mod xchacha20 {
 
     #[test]
     fn xchacha20_encryption() {
-        let mut cipher = XChaCha20::new(&GenericArray::from(KEY), &GenericArray::from(IV));
+        let mut cipher = XChaCha20::new(&Key::from(KEY), &XNonce::from(IV));
         let mut buf = PLAINTEXT.clone();
 
         // The test vectors omit the first 64-bytes of the keystream
@@ -130,10 +130,9 @@ mod xchacha20 {
 // Legacy "djb" version of ChaCha20 (64-bit nonce)
 #[cfg(feature = "legacy")]
 mod legacy {
-    use chacha20::ChaCha20Legacy;
-    use stream_cipher::{
-        generic_array::GenericArray, NewStreamCipher, StreamCipher, SyncStreamCipherSeek,
-    };
+    use chacha20::{ChaCha20Legacy, Key, LegacyNonce};
+    use stream_cipher::{new_seek_test, new_sync_test};
+    use stream_cipher::{NewStreamCipher, StreamCipher, SyncStreamCipherSeek};
 
     new_sync_test!(chacha20_legacy_core, ChaCha20Legacy, "chacha20-legacy");
     new_seek_test!(chacha20_legacy_seek, ChaCha20Legacy, "chacha20-legacy");
@@ -176,10 +175,8 @@ mod legacy {
         for idx in 0..256 {
             for middle in idx..256 {
                 for last in middle..256 {
-                    let mut cipher = ChaCha20Legacy::new(
-                        &GenericArray::from(KEY_LONG),
-                        &GenericArray::from(IV_LONG),
-                    );
+                    let mut cipher =
+                        ChaCha20Legacy::new(&Key::from(KEY_LONG), &LegacyNonce::from(IV_LONG));
                     let mut buf = [0; 256];
 
                     cipher.seek(idx as u64);


### PR DESCRIPTION
Adds the following type aliases (ala #146):

- `Key`: ChaCha(*) key (including XChaCha20)
- `Nonce`: IETF variant's 96-bit nonce
- `XNonce`: EXtended 96-bit nonce for XChaCha20
- `LegacyNonce`: 64-bit nonce for the legacy "djb" variant