### PR TITLE
chacha20/salsa20: documentation improvements

### DIFF
--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -42,3 +42,4 @@ harness = false
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/chacha20/src/legacy.rs
+++ b/chacha20/src/legacy.rs
@@ -5,11 +5,13 @@ use stream_cipher::consts::{U32, U8};
 use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
 
 /// Size of the nonce for the legacy ChaCha20 stream cipher
+#[cfg_attr(docsrs, doc(cfg(feature = "legacy")))]
 pub type LegacyNonce = stream_cipher::Nonce<ChaCha20Legacy>;
 
 /// The ChaCha20 stream cipher (legacy "djb" construction with 64-bit nonce).
 ///
 /// The `legacy` Cargo feature must be enabled to use this.
+#[cfg_attr(docsrs, doc(cfg(feature = "legacy")))]
 pub struct ChaCha20Legacy(ChaCha20);
 
 impl NewStreamCipher for ChaCha20Legacy {

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -22,6 +22,19 @@
 //!
 //! USE AT YOUR OWN RISK!
 //!
+//! # Diagram
+//!
+//! This diagram illustrates the ChaCha quarter round function.
+//! Each round consists of four quarter-rounds:
+//!
+//! <img src="https://raw.githubusercontent.com/RustCrypto/meta/master/img/stream-ciphers/chacha20.png" width="300px">
+//!
+//! Legend:
+//!
+//! - ⊞ add
+//! - ‹‹‹ rotate
+//! - ⊕ xor
+//!
 //! # Usage
 //!
 //! ```
@@ -51,23 +64,23 @@
 //! [Salsa20]: https://docs.rs/salsa20
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
-
-#[cfg(feature = "stream-cipher")]
-pub use stream_cipher;
 
 mod block;
 #[cfg(feature = "stream-cipher")]
 pub(crate) mod cipher;
 #[cfg(feature = "legacy")]
 mod legacy;
+#[cfg(feature = "rng")]
+mod rng;
 mod rounds;
 #[cfg(feature = "xchacha20")]
 mod xchacha20;
 
-#[cfg(feature = "rng")]
-mod rng;
+#[cfg(feature = "stream-cipher")]
+pub use stream_cipher;
 
 #[cfg(feature = "stream-cipher")]
 pub use self::cipher::{ChaCha12, ChaCha20, ChaCha8, Cipher, Key, Nonce};

--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -13,6 +13,7 @@ macro_rules! impl_chacha_rng {
     ($name:ident, $core:ident, $rounds:ident, $doc:expr) => {
         #[doc = $doc]
         #[derive(Clone, Debug)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "rng")))]
         pub struct $name(BlockRng<$core>);
 
         impl SeedableRng for $name {
@@ -51,6 +52,7 @@ macro_rules! impl_chacha_rng {
 
         #[doc = "Core random number generator, for use with [`rand_core::block::BlockRng`]"]
         #[derive(Clone, Debug)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "rng")))]
         pub struct $core {
             block: Block<$rounds>,
             counter: u64,

--- a/chacha20/src/xchacha20.rs
+++ b/chacha20/src/xchacha20.rs
@@ -13,6 +13,7 @@ use stream_cipher::{
 use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
 
 /// EXtended ChaCha20 nonce (192-bit/24-byte)
+#[cfg_attr(docsrs, doc(cfg(feature = "xchacha20")))]
 pub type XNonce = stream_cipher::Nonce<XChaCha20>;
 
 /// XChaCha20 is a ChaCha20 variant with an extended 192-bit (24-byte) nonce.
@@ -33,6 +34,7 @@ pub type XNonce = stream_cipher::Nonce<XChaCha20>;
 ///
 /// The `xchacha20` Cargo feature must be enabled in order to use this
 /// (which it is by default).
+#[cfg_attr(docsrs, doc(cfg(feature = "xchacha20")))]
 pub struct XChaCha20(ChaCha20);
 
 impl NewStreamCipher for XChaCha20 {

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -21,3 +21,7 @@ stream-cipher = { version = "0.4.1", features = ["dev"] }
 default = ["xsalsa20"]
 hsalsa20 = ["xsalsa20"]
 xsalsa20 = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -8,6 +8,21 @@
 //! This crate does not ensure ciphertexts are authentic! Thus ciphertext integrity
 //! is not verified, which can lead to serious vulnerabilities!
 //!
+//! USE AT YOUR OWN RISK!
+//!
+//! # Diagram
+//!
+//! This diagram illustrates the Salsa quarter round function.
+//! Each round consists of four quarter-rounds:
+//!
+//! <img src="https://raw.githubusercontent.com/RustCrypto/meta/master/img/stream-ciphers/salsa20.png" width="300px">
+//!
+//! Legend:
+//!
+//! - ⊞ add
+//! - ‹‹‹ rotate
+//! - ⊕ xor
+//!
 //! # Usage
 //!
 //! ```
@@ -34,6 +49,7 @@
 //! ```
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]

--- a/salsa20/src/xsalsa20.rs
+++ b/salsa20/src/xsalsa20.rs
@@ -9,6 +9,7 @@ use stream_cipher::{
 use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
 
 /// EXtended Salsa20 nonce (192-bit/24-byte)
+#[cfg_attr(docsrs, doc(cfg(feature = "xsalsa20")))]
 pub type XNonce = stream_cipher::Nonce<XSalsa20>;
 
 /// XSalsa20 is a Salsa20 variant with an extended 192-bit (24-byte) nonce.
@@ -19,6 +20,7 @@ pub type XNonce = stream_cipher::Nonce<XSalsa20>;
 ///
 /// The `xsalsa20` Cargo feature must be enabled in order to use this
 /// (which it is by default).
+#[cfg_attr(docsrs, doc(cfg(feature = "xsalsa20")))]
 pub struct XSalsa20(Salsa20);
 
 impl NewStreamCipher for XSalsa20 {
@@ -73,6 +75,7 @@ impl SyncStreamCipherSeek for XSalsa20 {
 /// - Nonce (`u32` x 4)
 ///
 /// It produces 256-bits of output suitable for use as a Salsa20 key
+#[cfg_attr(docsrs, doc(cfg(feature = "hsalsa20")))]
 pub fn hsalsa20(key: &Key, input: &GenericArray<u8, U16>) -> GenericArray<u8, U32> {
     let mut state = [0u32; 16];
 


### PR DESCRIPTION
Adds `doc(cfg(...))` for docs.rs as well as cipher diagrams