### PR TITLE
chacha20 v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chacha20"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "criterion",
  "criterion-cycles-per-byte",

--- a/chacha20/CHANGELOG.md
+++ b/chacha20/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.2 (2020-06-11)
+### Added
+- Documentation improvements ([#149])
+- `Key`, `Nonce`, `XNonce`, and `LegacyNonce` type aliases ([#147])
+
+[#149]: https://github.com/RustCrypto/stream-ciphers/pull/149
+[#147]: https://github.com/RustCrypto/stream-ciphers/pull/147
+
 ## 0.4.1 (2020-06-06)
 ### Fixed
 - Links in documentation ([#142])

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
### Added
- Documentation improvements ([#149])
- `Key`, `Nonce`, `XNonce`, and `LegacyNonce` type aliases ([#147])

[#149]: https://github.com/RustCrypto/stream-ciphers/pull/149
[#147]: https://github.com/RustCrypto/stream-ciphers/pull/147