### PR TITLE
salsa20 v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "salsa20"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "stream-cipher",
  "zeroize",

--- a/salsa20/CHANGELOG.md
+++ b/salsa20/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.1 (2020-06-11)
+### Added
+- Documentation improvements ([#149])
+- `Key`, `Nonce`, and `XNonce` type aliases ([#146])
+
+### Changed
+- Bump `stream-cipher` to v0.4.1 ([#148])
+
+[#149]: https://github.com/RustCrypto/stream-ciphers/pull/149
+[#148]: https://github.com/RustCrypto/stream-ciphers/pull/148
+[#146]: https://github.com/RustCrypto/stream-ciphers/pull/146
+
 ## 0.5.0 (2020-06-06)
 ### Added
 - `Salsa8` and `Salsa12` variants ([#133])

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa20"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Salsa20 Stream Cipher"


### PR DESCRIPTION
### Added
- Documentation improvements ([#149])
- `Key`, `Nonce`, and `XNonce` type aliases ([#146])

### Changed
- Bump `stream-cipher` to v0.4.1 ([#148])

[#149]: https://github.com/RustCrypto/stream-ciphers/pull/149
[#148]: https://github.com/RustCrypto/stream-ciphers/pull/148
[#146]: https://github.com/RustCrypto/stream-ciphers/pull/146