### PR TITLE
salsa20: fix `stream-cipher` version requirement

### DIFF
--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = "0.4"
+stream-cipher = "0.4.1"
 zeroize = { version = "1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This didn't get properly updated