### PR TITLE
salsa20 v0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "salsa20"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "stream-cipher",
  "zeroize",

--- a/salsa20/CHANGELOG.md
+++ b/salsa20/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.2 (2020-06-11)
+### Changed
+- Use `Key` and `Nonce` in usage docs ([#155])
+
+### Fixed
+- `stream-cipher` version requirement ([#152])
+
+[#155]: https://github.com/RustCrypto/stream-ciphers/pull/155
+[#152]: https://github.com/RustCrypto/stream-ciphers/pull/152
+
 ## 0.5.1 (2020-06-11)
 ### Added
 - Documentation improvements ([#149])

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa20"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Salsa20 Stream Cipher"


### PR DESCRIPTION
### Changed
- Use `Key` and `Nonce` in usage docs ([#155])

### Fixed
- `stream-cipher` version requirement ([#152])

[#155]: https://github.com/RustCrypto/stream-ciphers/pull/155
[#152]: https://github.com/RustCrypto/stream-ciphers/pull/152