### PR TITLE
Upgrade to stream-cipher v0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ dependencies = [
  "aes-soft",
  "aesni",
  "ctr",
- "stream-cipher",
+ "stream-cipher 0.7.0",
 ]
 
 [[package]]
@@ -40,7 +40,7 @@ checksum = "0a6fe808308bb07d393e2ea47780043ec47683fcf19cf5efc8ca51c50cc8c68a"
 dependencies = [
  "block-cipher",
  "opaque-debug",
- "stream-cipher",
+ "stream-cipher 0.6.0",
 ]
 
 [[package]]
@@ -70,7 +70,7 @@ version = "0.5.0"
 dependencies = [
  "aes",
  "hex-literal",
- "stream-cipher",
+ "stream-cipher 0.7.0",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ version = "0.5.0"
 dependencies = [
  "aes",
  "hex-literal",
- "stream-cipher",
+ "stream-cipher 0.7.0",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ version = "0.5.0"
 dependencies = [
  "hex-literal",
  "rand_core",
- "stream-cipher",
+ "stream-cipher 0.7.0",
  "zeroize",
 ]
 
@@ -97,7 +97,7 @@ name = "ctr"
 version = "0.5.0"
 dependencies = [
  "aes",
- "stream-cipher",
+ "stream-cipher 0.7.0",
 ]
 
 [[package]]
@@ -114,7 +114,7 @@ dependencies = [
 name = "hc-256"
 version = "0.2.0"
 dependencies = [
- "stream-cipher",
+ "stream-cipher 0.7.0",
  "zeroize",
 ]
 
@@ -143,7 +143,7 @@ version = "0.3.0"
 dependencies = [
  "aes",
  "hex-literal",
- "stream-cipher",
+ "stream-cipher 0.7.0",
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 name = "salsa20"
 version = "0.6.0"
 dependencies = [
- "stream-cipher",
+ "stream-cipher 0.7.0",
  "zeroize",
 ]
 
@@ -177,6 +177,16 @@ name = "stream-cipher"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fa7a9adbc5572d9cb8f9d1e85b8f450038852bc88ed87527b8ce207bc9baaa3"
+dependencies = [
+ "block-cipher",
+ "generic-array",
+]
+
+[[package]]
+name = "stream-cipher"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e6079ef5bde141fb7c88fc8e6010218f00051b17fa6dd6b816f10c243c34d5"
 dependencies = [
  "blobby",
  "block-cipher",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2bc6d3f370b5666245ff421e231cba4353df936e26986d2918e61a8fd6aef6"
 dependencies = [
  "aes-soft",
- "aesni",
+ "aesni 0.8.0",
  "block-cipher",
 ]
 
@@ -16,9 +16,9 @@ name = "aes-ctr"
 version = "0.5.0"
 dependencies = [
  "aes-soft",
- "aesni",
+ "aesni 0.9.0",
  "ctr",
- "stream-cipher 0.7.0",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -40,7 +40,17 @@ checksum = "0a6fe808308bb07d393e2ea47780043ec47683fcf19cf5efc8ca51c50cc8c68a"
 dependencies = [
  "block-cipher",
  "opaque-debug",
- "stream-cipher 0.6.0",
+]
+
+[[package]]
+name = "aesni"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a4d655ae633a96d0acaf0fd7e76aafb8ca5732739bba37aac6f882c8fce656"
+dependencies = [
+ "block-cipher",
+ "opaque-debug",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -70,7 +80,7 @@ version = "0.5.0"
 dependencies = [
  "aes",
  "hex-literal",
- "stream-cipher 0.7.0",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -79,7 +89,7 @@ version = "0.5.0"
 dependencies = [
  "aes",
  "hex-literal",
- "stream-cipher 0.7.0",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -88,7 +98,7 @@ version = "0.5.0"
 dependencies = [
  "hex-literal",
  "rand_core",
- "stream-cipher 0.7.0",
+ "stream-cipher",
  "zeroize",
 ]
 
@@ -97,7 +107,7 @@ name = "ctr"
 version = "0.5.0"
 dependencies = [
  "aes",
- "stream-cipher 0.7.0",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -114,7 +124,7 @@ dependencies = [
 name = "hc-256"
 version = "0.2.0"
 dependencies = [
- "stream-cipher 0.7.0",
+ "stream-cipher",
  "zeroize",
 ]
 
@@ -143,7 +153,7 @@ version = "0.3.0"
 dependencies = [
  "aes",
  "hex-literal",
- "stream-cipher 0.7.0",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -168,18 +178,8 @@ checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 name = "salsa20"
 version = "0.6.0"
 dependencies = [
- "stream-cipher 0.7.0",
+ "stream-cipher",
  "zeroize",
-]
-
-[[package]]
-name = "stream-cipher"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa7a9adbc5572d9cb8f9d1e85b8f450038852bc88ed87527b8ce207bc9baaa3"
-dependencies = [
- "block-cipher",
- "generic-array",
 ]
 
 [[package]]

--- a/aes-ctr/CHANGELOG.md
+++ b/aes-ctr/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.5.0 (2020-08-14)
+## 0.5.0 (2020-08-25)
 ### Changed
-- Bump `stream-cipher` dependency to v0.6, implement the `FromBlockCipher` trait ([#161])
+- Bump `stream-cipher` dependency to v0.7, implement the `FromBlockCipher` trait ([#161], [#164])
 
 [#161]: https://github.com/RustCrypto/stream-ciphers/pull/161
+[#164]: https://github.com/RustCrypto/stream-ciphers/pull/164
 
 ## 0.4.0 (2020-06-08)
 ### Changed

--- a/aes-ctr/Cargo.toml
+++ b/aes-ctr/Cargo.toml
@@ -19,7 +19,7 @@ ctr = { version = "0.5", path = "../ctr" }
 aes-soft = "0.5"
 
 [target.'cfg(all(target_feature = "aes", target_feature = "sse2", target_feature = "ssse3", any(target_arch = "x86_64", target_arch = "x86")))'.dependencies]
-aesni = "0.8"
+aesni = "0.9"
 
 [dev-dependencies]
 stream-cipher = { version = "0.7", features = ["dev"] }

--- a/aes-ctr/Cargo.toml
+++ b/aes-ctr/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = "0.6"
+stream-cipher = "0.7"
 
 [target.'cfg(not(all(target_feature = "aes", target_feature = "sse2", target_feature = "ssse3", any(target_arch = "x86_64", target_arch = "x86"))))'.dependencies]
 ctr = { version = "0.5", path = "../ctr" }
@@ -22,4 +22,4 @@ aes-soft = "0.5"
 aesni = "0.8"
 
 [dev-dependencies]
-stream-cipher = { version = "0.6", features = ["dev"] }
+stream-cipher = { version = "0.7", features = ["dev"] }

--- a/aes-ctr/tests/lib.rs
+++ b/aes-ctr/tests/lib.rs
@@ -4,6 +4,6 @@ use aes_ctr::{Aes128Ctr, Aes256Ctr};
 use stream_cipher::{new_seek_test, new_sync_test};
 
 new_sync_test!(aes128_ctr_core, Aes128Ctr, "aes128-ctr");
-new_seek_test!(aes128_ctr_seek, Aes128Ctr, "aes128-ctr");
 new_sync_test!(aes256_ctr_core, Aes256Ctr, "aes256-ctr");
-new_seek_test!(aes256_ctr_seek, Aes256Ctr, "aes256-ctr");
+new_seek_test!(aes128_ctr_seek, Aes128Ctr);
+new_seek_test!(aes256_ctr_seek, Aes256Ctr);

--- a/cfb-mode/CHANGELOG.md
+++ b/cfb-mode/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.5.0 (2020-08-14)
+## 0.5.0 (2020-08-25)
 ### Changed
-- Bump `stream-cipher` dependency to v0.6, implement the `FromBlockCipher` trait ([#161])
+- Bump `stream-cipher` dependency to v0.7, implement the `FromBlockCipher` trait ([#161], [#164])
 
 [#161]: https://github.com/RustCrypto/stream-ciphers/pull/161
+[#164]: https://github.com/RustCrypto/stream-ciphers/pull/164
 
 ## 0.4.0 (2020-06-08)
 ### Changed

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = { version = "0.6", features = ["block-cipher"] }
+stream-cipher = { version = "0.7", features = ["block-cipher"] }
 
 [dev-dependencies]
 aes = "0.5"
-stream-cipher = { version = "0.6", features = ["dev"] }
+stream-cipher = { version = "0.7", features = ["dev"] }
 hex-literal = "0.2"

--- a/cfb8/CHANGELOG.md
+++ b/cfb8/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.5.0 (2020-08-14)
+## 0.5.0 (2020-08-25)
 ### Changed
-- Bump `stream-cipher` dependency to v0.6, implement the `FromBlockCipher` trait ([#161])
+- Bump `stream-cipher` dependency to v0.7, implement the `FromBlockCipher` trait ([#161], [#164])
 
 [#161]: https://github.com/RustCrypto/stream-ciphers/pull/161
+[#164]: https://github.com/RustCrypto/stream-ciphers/pull/164
 
 ## 0.4.0 (2020-06-08)
 ### Changed

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = { version = "0.6", features = ["block-cipher"] }
+stream-cipher = { version = "0.7", features = ["block-cipher"] }
 
 [dev-dependencies]
 aes = "0.5"
-stream-cipher = { version = "0.6", features = ["dev"] }
+stream-cipher = { version = "0.7", features = ["dev"] }
 hex-literal = "0.2"

--- a/chacha20/CHANGELOG.md
+++ b/chacha20/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.5.0 (2020-08-14)
+## 0.5.0 (2020-08-25)
 ### Changed
-- Bump `stream-cipher` dependency to v0.6 ([#161])
+- Bump `stream-cipher` dependency to v0.7 ([#161], [#164])
 
 [#161]: https://github.com/RustCrypto/stream-ciphers/pull/161
+[#164]: https://github.com/RustCrypto/stream-ciphers/pull/164
 
 ## 0.4.3 (2020-06-11)
 ### Changed

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -18,11 +18,11 @@ edition = "2018"
 
 [dependencies]
 rand_core = { version = "0.5", optional = true, default-features = false }
-stream-cipher = { version = "0.6", optional = true }
+stream-cipher = { version = "0.7", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-stream-cipher = { version = "0.6", features = ["dev"] }
+stream-cipher = { version = "0.7", features = ["dev"] }
 hex-literal = "0.2"
 
 [features]

--- a/chacha20/src/cipher.rs
+++ b/chacha20/src/cipher.rs
@@ -160,7 +160,9 @@ impl<R: Rounds> SyncStreamCipherSeek for Cipher<R> {
         let res = pos.to_block_byte(BLOCK_SIZE as u8)?;
         self.counter = res.0;
         self.buffer_pos = res.1;
-        self.generate_block(self.counter);
+        if self.buffer_pos != 0 {
+            self.generate_block(self.counter);
+        }
         Ok(())
     }
 }

--- a/chacha20/src/cipher.rs
+++ b/chacha20/src/cipher.rs
@@ -10,12 +10,13 @@ use crate::{
     BLOCK_SIZE, MAX_BLOCKS,
 };
 use core::{
-    cmp,
     convert::TryInto,
     fmt::{self, Debug},
 };
-use stream_cipher::consts::{U12, U32};
-use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
+use stream_cipher::{
+    consts::{U12, U32},
+    LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek, OverflowError, SeekNum,
+};
 
 /// ChaCha8 stream cipher (reduced-round variant of ChaCha20 with 8 rounds)
 pub type ChaCha8 = Cipher<R8>;
@@ -61,7 +62,7 @@ pub struct Cipher<R: Rounds> {
     buffer: Buffer,
 
     /// Position within buffer, or `None` if the buffer is not in use
-    buffer_pos: Option<u8>,
+    buffer_pos: u8,
 
     /// Current counter value relative to the start of the keystream
     counter: u64,
@@ -93,7 +94,7 @@ impl<R: Rounds> NewStreamCipher for Cipher<R> {
         Self {
             block,
             buffer: [0u8; BUFFER_SIZE],
-            buffer_pos: None,
+            buffer_pos: 0,
             counter: 0,
             counter_offset,
         }
@@ -103,98 +104,78 @@ impl<R: Rounds> NewStreamCipher for Cipher<R> {
 impl<R: Rounds> SyncStreamCipher for Cipher<R> {
     fn try_apply_keystream(&mut self, mut data: &mut [u8]) -> Result<(), LoopError> {
         self.check_data_len(data)?;
+        let pos = self.buffer_pos as usize;
 
-        // xor with leftover bytes from the last call if any
-        if let Some(pos) = self.buffer_pos {
-            let pos = pos as usize;
-
-            if data.len() >= BUFFER_SIZE - pos {
-                let buf = &self.buffer[pos..];
-                let (r, l) = data.split_at_mut(buf.len());
-                data = l;
-                xor(r, buf);
-                self.buffer_pos = None;
-            } else {
-                let buf = &self.buffer[pos..pos.checked_add(data.len()).unwrap()];
-                xor(data, buf);
-                self.buffer_pos = Some(pos.checked_add(data.len()).unwrap() as u8);
-                return Ok(());
-            }
+        if data.len() == 0 {
+            return Ok(());
         }
 
         let mut counter = self.counter;
+        // xor with leftover bytes from the last call if any
+        if pos != 0 {
+            if data.len() < BUFFER_SIZE - pos {
+                let n = pos + data.len();
+                xor(data, &self.buffer[pos..n]);
+                self.buffer_pos = n as u8;
+                return Ok(())
+            } else {
+                let (l, r) = data.split_at_mut(BUFFER_SIZE - pos);
+                data = r;
+                xor(l, &self.buffer[pos..]);
+                counter += 1;
+            }
+        }
 
-        while data.len() >= BUFFER_SIZE {
-            let (l, r) = { data }.split_at_mut(BUFFER_SIZE);
-            data = r;
-
+        let mut chunks = data.chunks_exact_mut(BUFFER_SIZE);
+        for chunk in &mut chunks {
             // TODO(tarcieri): double check this should be checked and not wrapping
             let counter_with_offset = self.counter_offset.checked_add(counter).unwrap();
-            self.block.apply_keystream(counter_with_offset, l);
-
+            self.block.apply_keystream(counter_with_offset, chunk);
             counter = counter.checked_add(COUNTER_INCR).unwrap();
         }
 
-        if !data.is_empty() {
-            self.generate_block(counter);
-            counter = counter.checked_add(COUNTER_INCR).unwrap();
-            let n = data.len();
-            xor(data, &self.buffer[..n]);
-            self.buffer_pos = Some(n as u8);
-        }
-
+        let rem = chunks.into_remainder();
+        self.buffer_pos = rem.len() as u8;
         self.counter = counter;
+        if rem.len() != 0 {
+            self.generate_block(counter);
+            xor(rem, &self.buffer[..rem.len()]);
+        }
 
         Ok(())
     }
 }
 
 impl<R: Rounds> SyncStreamCipherSeek for Cipher<R> {
-    fn current_pos(&self) -> u64 {
-        let bs = BLOCK_SIZE as u64;
-
-        if let Some(pos) = self.buffer_pos {
-            (self.counter.wrapping_sub(1) * bs)
-                .checked_add(u64::from(pos))
-                .unwrap()
-        } else {
-            self.counter * bs
-        }
+    fn try_current_pos<T: SeekNum>(&self) -> Result<T, OverflowError> {
+        T::from_block_byte(self.counter, self.buffer_pos, BLOCK_SIZE as u8)
     }
 
-    fn seek(&mut self, pos: u64) {
-        let bs = BLOCK_SIZE as u64;
-        self.counter = pos / bs;
-        let rem = pos % bs;
-
-        if rem == 0 {
-            self.buffer_pos = None;
-        } else {
-            self.generate_block(self.counter);
-            self.counter = self.counter.checked_add(COUNTER_INCR).unwrap();
-            self.buffer_pos = Some(rem as u8);
-        }
+    fn try_seek<T: SeekNum>(&mut self, pos: T) -> Result<(), LoopError> {
+        let res = pos.to_block_byte(BLOCK_SIZE as u8)?;
+        self.counter = res.0;
+        self.buffer_pos = res.1;
+        self.generate_block(self.counter);
+        Ok(())
     }
 }
 
 impl<R: Rounds> Cipher<R> {
     /// Check data length
     fn check_data_len(&self, data: &[u8]) -> Result<(), LoopError> {
-        let dlen = data.len()
-            - self
-                .buffer_pos
-                .map(|pos| cmp::min(BUFFER_SIZE - pos as usize, data.len()))
-                .unwrap_or_default();
-
-        let data_blocks = dlen / BLOCK_SIZE + if data.len() % BLOCK_SIZE != 0 { 1 } else { 0 };
-
-        if let Some(new_counter) = self.counter.checked_add(data_blocks as u64) {
-            if new_counter <= MAX_BLOCKS as u64 {
-                return Ok(());
-            }
+        let leftover_bytes = BLOCK_SIZE - self.buffer_pos as usize;
+        if data.len() < leftover_bytes {
+            return Ok(());
         }
-
-        Err(LoopError)
+        let blocks = 1 + (data.len() - leftover_bytes) / BLOCK_SIZE;
+        let res = self.counter
+            .checked_add(blocks as u64)
+            .ok_or(LoopError)?;
+        if res <= MAX_BLOCKS as u64 {
+            Ok(())
+        } else {
+            Err(LoopError)
+        }
     }
 
     /// Generate a block, storing it in the internal buffer

--- a/chacha20/src/cipher.rs
+++ b/chacha20/src/cipher.rs
@@ -148,7 +148,10 @@ impl<R: Rounds> SyncStreamCipherSeek for Cipher<R> {
         let (counter, pos) = if self.buffer_pos < BLOCK_SIZE as u8 {
             (self.counter, self.buffer_pos)
         } else {
-            (self.counter.checked_add(1).ok_or(OverflowError)?, self.buffer_pos - BLOCK_SIZE as u8)
+            (
+                self.counter.checked_add(1).ok_or(OverflowError)?,
+                self.buffer_pos - BLOCK_SIZE as u8,
+            )
         };
         T::from_block_byte(counter, pos, BLOCK_SIZE as u8)
     }

--- a/chacha20/src/legacy.rs
+++ b/chacha20/src/legacy.rs
@@ -1,8 +1,10 @@
 //! Legacy version of ChaCha20 with a 64-bit nonce
 
 use crate::cipher::{ChaCha20, Key};
-use stream_cipher::consts::{U32, U8};
-use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
+use stream_cipher::{
+    consts::{U32, U8},
+    LoopError, NewStreamCipher, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
+};
 
 /// Size of the nonce for the legacy ChaCha20 stream cipher
 #[cfg_attr(docsrs, doc(cfg(feature = "legacy")))]
@@ -35,11 +37,11 @@ impl SyncStreamCipher for ChaCha20Legacy {
 }
 
 impl SyncStreamCipherSeek for ChaCha20Legacy {
-    fn current_pos(&self) -> u64 {
-        self.0.current_pos()
+    fn try_current_pos<T: SeekNum>(&self) -> Result<T, OverflowError> {
+        self.0.try_current_pos()
     }
 
-    fn seek(&mut self, pos: u64) {
-        self.0.seek(pos);
+    fn try_seek<T: SeekNum>(&mut self, pos: T) -> Result<(), LoopError> {
+        self.0.try_seek(pos)
     }
 }

--- a/chacha20/src/xchacha20.rs
+++ b/chacha20/src/xchacha20.rs
@@ -9,7 +9,7 @@ use core::convert::TryInto;
 use stream_cipher::{
     consts::{U16, U24, U32},
     generic_array::GenericArray,
-    LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek, OverflowError, SeekNum,
+    LoopError, NewStreamCipher, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
 };
 
 /// EXtended ChaCha20 nonce (192-bits/24-bytes)

--- a/chacha20/src/xchacha20.rs
+++ b/chacha20/src/xchacha20.rs
@@ -9,8 +9,8 @@ use core::convert::TryInto;
 use stream_cipher::{
     consts::{U16, U24, U32},
     generic_array::GenericArray,
+    LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek, OverflowError, SeekNum,
 };
-use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
 
 /// EXtended ChaCha20 nonce (192-bits/24-bytes)
 #[cfg_attr(docsrs, doc(cfg(feature = "xchacha20")))]
@@ -61,12 +61,12 @@ impl SyncStreamCipher for XChaCha20 {
 }
 
 impl SyncStreamCipherSeek for XChaCha20 {
-    fn current_pos(&self) -> u64 {
-        self.0.current_pos()
+    fn try_current_pos<T: SeekNum>(&self) -> Result<T, OverflowError> {
+        self.0.try_current_pos()
     }
 
-    fn seek(&mut self, pos: u64) {
-        self.0.seek(pos);
+    fn try_seek<T: SeekNum>(&mut self, pos: T) -> Result<(), LoopError> {
+        self.0.try_seek(pos)
     }
 }
 

--- a/chacha20/tests/lib.rs
+++ b/chacha20/tests/lib.rs
@@ -7,12 +7,15 @@ use stream_cipher::{new_seek_test, new_sync_test};
 new_sync_test!(chacha20_core, ChaCha20, "chacha20");
 new_seek_test!(chacha20_seek, ChaCha20);
 
-#[cfg(features = "xchacha20")]
+#[cfg(feature = "xchacha20")]
 #[rustfmt::skip]
 mod xchacha20 {
     use chacha20::{Key, XChaCha20, XNonce};
     use stream_cipher::{NewStreamCipher, StreamCipher};
     use hex_literal::hex;
+    use stream_cipher::new_seek_test;
+
+    new_seek_test!(xchacha20_seek, XChaCha20);
 
     //
     // XChaCha20 test vectors from:
@@ -103,7 +106,7 @@ mod legacy {
     use hex_literal::hex;
 
     new_sync_test!(chacha20_legacy_core, ChaCha20Legacy, "chacha20-legacy");
-    new_seek_test!(chacha20_legacy_seek, ChaCha20Legacy, "chacha20-legacy");
+    new_seek_test!(chacha20_legacy_seek, ChaCha20Legacy);
 
     const KEY_LONG: [u8; 32] = hex!("
         0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20

--- a/chacha20/tests/lib.rs
+++ b/chacha20/tests/lib.rs
@@ -5,7 +5,7 @@ use stream_cipher::{new_seek_test, new_sync_test};
 
 // IETF version of ChaCha20 (96-bit nonce)
 new_sync_test!(chacha20_core, ChaCha20, "chacha20");
-new_seek_test!(chacha20_seek, ChaCha20, "chacha20");
+new_seek_test!(chacha20_seek, ChaCha20);
 
 #[cfg(features = "xchacha20")]
 #[rustfmt::skip]

--- a/ctr/CHANGELOG.md
+++ b/ctr/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.5.0 (2020-08-14)
+## 0.5.0 (2020-08-25)
 ### Changed
-- Bump `stream-cipher` dependency to v0.6, implement the `FromBlockCipher` trait ([#161])
+- Bump `stream-cipher` dependency to v0.7, implement the `FromBlockCipher` trait ([#161], [#164])
 
 [#161]: https://github.com/RustCrypto/stream-ciphers/pull/161
+[#164]: https://github.com/RustCrypto/stream-ciphers/pull/164
 
 ## 0.4.0 (2020-06-06)
 ### Changed

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = { version = "0.6", features = ["block-cipher"] }
+stream-cipher = { version = "0.7", features = ["block-cipher"]  }
 
 [dev-dependencies]
 aes = "0.5"
-stream-cipher = { version = "0.6", features = ["dev"] }
+stream-cipher = { version = "0.7", features = ["block-cipher", "dev"]  }

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = { version = "0.7", features = ["block-cipher"]  }
+stream-cipher = { version = "0.7", features = ["block-cipher"] }
 
 [dev-dependencies]
 aes = "0.5"
-stream-cipher = { version = "0.7", features = ["block-cipher", "dev"]  }
+stream-cipher = { version = "0.7", features = ["block-cipher", "dev"] }

--- a/ctr/src/lib.rs
+++ b/ctr/src/lib.rs
@@ -170,9 +170,11 @@ where
 
     fn try_seek<T: SeekNum>(&mut self, pos: T) -> Result<(), LoopError> {
         let res = pos.to_block_byte(C::BlockSize::U8)?;
-        self.block = self.generate_block(res.0);
         self.counter = res.0;
         self.pos = res.1;
+        if self.pos != 0 {
+            self.block = self.generate_block(self.counter);
+        }
         Ok(())
     }
 }

--- a/ctr/src/lib.rs
+++ b/ctr/src/lib.rs
@@ -150,7 +150,7 @@ where
         let rem = chunks.into_remainder();
         self.pos = rem.len() as u8;
         self.counter = counter;
-        if rem.len() != 0 {
+        if !rem.is_empty() {
             self.block = self.generate_block(counter);
             xor(rem, &self.block[..rem.len()]);
         }

--- a/ctr/tests/lib.rs
+++ b/ctr/tests/lib.rs
@@ -2,6 +2,6 @@ type Aes128Ctr = ctr::Ctr128<aes::Aes128>;
 type Aes256Ctr = ctr::Ctr128<aes::Aes256>;
 
 stream_cipher::new_sync_test!(aes128_ctr_core, Aes128Ctr, "aes128-ctr");
-stream_cipher::new_seek_test!(aes128_ctr_seek, Aes128Ctr, "aes128-ctr");
 stream_cipher::new_sync_test!(aes256_ctr_core, Aes256Ctr, "aes256-ctr");
-stream_cipher::new_seek_test!(aes256_ctr_seek, Aes256Ctr, "aes256-ctr");
+stream_cipher::new_seek_test!(aes128_ctr_seek, Aes128Ctr);
+stream_cipher::new_seek_test!(aes256_ctr_seek, Aes256Ctr);

--- a/hc-256/CHANGELOG.md
+++ b/hc-256/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (2020-08-14)
+## 0.2.0 (2020-08-25)
 ### Changed
-- Bump `stream-cipher` dependency to v0.6 ([#161])
+- Bump `stream-cipher` dependency to v0.7, rename `HC256` to `Hc256` ([#161], [#164])
 
 [#161]: https://github.com/RustCrypto/stream-ciphers/pull/161
+[#164]: https://github.com/RustCrypto/stream-ciphers/pull/164
 
 ## 0.1.0 (2020-06-08)
 ### Changed

--- a/hc-256/Cargo.toml
+++ b/hc-256/Cargo.toml
@@ -11,5 +11,5 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = "0.6"
+stream-cipher = "0.7"
 zeroize = { version = "1", optional = true }

--- a/hc-256/src/lib.rs
+++ b/hc-256/src/lib.rs
@@ -28,7 +28,7 @@ const IV_BITS: usize = 256;
 const IV_WORDS: usize = IV_BITS / 32;
 
 /// The HC-256 stream cipher
-pub struct HC256 {
+pub struct Hc256 {
     ptable: [u32; TABLE_SIZE],
     qtable: [u32; TABLE_SIZE],
     word: u32,
@@ -36,20 +36,20 @@ pub struct HC256 {
     offset: u8,
 }
 
-impl NewStreamCipher for HC256 {
+impl NewStreamCipher for Hc256 {
     /// Key size in bytes
     type KeySize = U32;
     /// Nonce size in bytes
     type NonceSize = U32;
 
     fn new(key: &GenericArray<u8, Self::KeySize>, iv: &GenericArray<u8, Self::NonceSize>) -> Self {
-        let mut out = HC256::create();
+        let mut out = Hc256::create();
         out.init(key.as_slice(), iv.as_slice());
         out
     }
 }
 
-impl StreamCipher for HC256 {
+impl StreamCipher for Hc256 {
     fn encrypt(&mut self, data: &mut [u8]) {
         self.process(data);
     }
@@ -59,9 +59,9 @@ impl StreamCipher for HC256 {
     }
 }
 
-impl HC256 {
-    fn create() -> HC256 {
-        HC256 {
+impl Hc256 {
+    fn create() -> Hc256 {
+        Hc256 {
             ptable: [0; TABLE_SIZE],
             qtable: [0; TABLE_SIZE],
             word: 0,
@@ -212,7 +212,7 @@ impl HC256 {
 }
 
 #[cfg(cargo_feature = "zeroize")]
-impl Zeroize for HC256 {
+impl Zeroize for Hc256 {
     fn zeroize(&mut self) {
         self.ptable.zeroize();
         self.qtable.zeroize();
@@ -223,7 +223,7 @@ impl Zeroize for HC256 {
 }
 
 #[cfg(cargo_feature = "zeroize")]
-impl Drop for HC256 {
+impl Drop for Hc256 {
     fn drop(&mut self) {
         self.zeroize();
     }

--- a/hc-256/tests/lib.rs
+++ b/hc-256/tests/lib.rs
@@ -1,4 +1,4 @@
-use hc_256::HC256;
+use hc_256::Hc256;
 use stream_cipher::{generic_array::GenericArray, NewStreamCipher, StreamCipher};
 
 #[cfg(test)]
@@ -50,7 +50,7 @@ const EXPECTED_PAPER_KEY1_IV0: [u8; 64] = [
 
 #[test]
 fn test_key0_iv0() {
-    let mut cipher = HC256::new(
+    let mut cipher = Hc256::new(
         &GenericArray::from(PAPER_KEY0),
         &GenericArray::from(PAPER_IV0),
     );
@@ -65,7 +65,7 @@ fn test_key0_iv0() {
 
 #[test]
 fn test_key0_iv0_offset_1() {
-    let mut cipher = HC256::new(
+    let mut cipher = Hc256::new(
         &GenericArray::from(PAPER_KEY0),
         &GenericArray::from(PAPER_IV0),
     );
@@ -86,7 +86,7 @@ fn test_key0_iv0_offset_1() {
 
 #[test]
 fn test_key0_iv0_offset_2() {
-    let mut cipher = HC256::new(
+    let mut cipher = Hc256::new(
         &GenericArray::from(PAPER_KEY0),
         &GenericArray::from(PAPER_IV0),
     );
@@ -107,7 +107,7 @@ fn test_key0_iv0_offset_2() {
 
 #[test]
 fn test_key0_iv0_offset_3() {
-    let mut cipher = HC256::new(
+    let mut cipher = Hc256::new(
         &GenericArray::from(PAPER_KEY0),
         &GenericArray::from(PAPER_IV0),
     );
@@ -128,7 +128,7 @@ fn test_key0_iv0_offset_3() {
 
 #[test]
 fn test_key0_iv0_offset_4() {
-    let mut cipher = HC256::new(
+    let mut cipher = Hc256::new(
         &GenericArray::from(PAPER_KEY0),
         &GenericArray::from(PAPER_IV0),
     );
@@ -149,7 +149,7 @@ fn test_key0_iv0_offset_4() {
 
 #[test]
 fn test_key0_iv0_offset_5() {
-    let mut cipher = HC256::new(
+    let mut cipher = Hc256::new(
         &GenericArray::from(PAPER_KEY0),
         &GenericArray::from(PAPER_IV0),
     );
@@ -170,7 +170,7 @@ fn test_key0_iv0_offset_5() {
 
 #[test]
 fn test_key0_iv0_offset_6() {
-    let mut cipher = HC256::new(
+    let mut cipher = Hc256::new(
         &GenericArray::from(PAPER_KEY0),
         &GenericArray::from(PAPER_IV0),
     );
@@ -191,7 +191,7 @@ fn test_key0_iv0_offset_6() {
 
 #[test]
 fn test_key0_iv0_offset_7() {
-    let mut cipher = HC256::new(
+    let mut cipher = Hc256::new(
         &GenericArray::from(PAPER_KEY0),
         &GenericArray::from(PAPER_IV0),
     );
@@ -212,7 +212,7 @@ fn test_key0_iv0_offset_7() {
 
 #[test]
 fn test_key0_iv0_offset_8() {
-    let mut cipher = HC256::new(
+    let mut cipher = Hc256::new(
         &GenericArray::from(PAPER_KEY0),
         &GenericArray::from(PAPER_IV0),
     );
@@ -233,7 +233,7 @@ fn test_key0_iv0_offset_8() {
 
 #[test]
 fn test_key1_iv0() {
-    let mut cipher = HC256::new(
+    let mut cipher = Hc256::new(
         &GenericArray::from(PAPER_KEY1),
         &GenericArray::from(PAPER_IV0),
     );
@@ -248,7 +248,7 @@ fn test_key1_iv0() {
 
 #[test]
 fn test_key0_iv1() {
-    let mut cipher = HC256::new(
+    let mut cipher = Hc256::new(
         &GenericArray::from(PAPER_KEY0),
         &GenericArray::from(PAPER_IV1),
     );

--- a/ofb/CHANGELOG.md
+++ b/ofb/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.0 (2020-08-14)
+## 0.3.0 (2020-08-25)
 ### Changed
-- Bump `stream-cipher` dependency to v0.6, implement the `FromBlockCipher` trait ([#161])
+- Bump `stream-cipher` dependency to v0.7, implement the `FromBlockCipher` trait ([#161], [#164])
 
 [#161]: https://github.com/RustCrypto/stream-ciphers/pull/161
+[#164]: https://github.com/RustCrypto/stream-ciphers/pull/164
 
 ## 0.2.0 (2020-06-08)
 ### Changed

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = { version = "0.6", features = ["block-cipher"] }
+stream-cipher = { version = "0.7", features = ["block-cipher"] }
 
 [dev-dependencies]
 aes = "0.5"
-stream-cipher = { version = "0.6", features = ["dev"] }
+stream-cipher = { version = "0.7", features = ["dev"] }
 hex-literal = "0.2"

--- a/salsa20/CHANGELOG.md
+++ b/salsa20/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.6.0 (2020-08-14)
+## 0.6.0 (2020-08-25)
 ### Changed
-- Bump `stream-cipher` dependency to v0.6 ([#161])
+- Bump `stream-cipher` dependency to v0.7 ([#161], [#164])
 
 [#161]: https://github.com/RustCrypto/stream-ciphers/pull/161
+[#164]: https://github.com/RustCrypto/stream-ciphers/pull/164
 
 ## 0.5.2 (2020-06-11)
 ### Changed

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -15,7 +15,7 @@ stream-cipher = "0.7"
 zeroize = { version = "1", optional = true }
 
 [dev-dependencies]
-stream-cipher = { version = "0.7", features = ["dev"]  }
+stream-cipher = { version = "0.7", features = ["dev"] }
 
 [features]
 default = ["xsalsa20"]

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = "0.6"
+stream-cipher = "0.7"
 zeroize = { version = "1", optional = true }
 
 [dev-dependencies]
-stream-cipher = { version = "0.6", features = ["dev"] }
+stream-cipher = { version = "0.7", features = ["dev"]  }
 
 [features]
 default = ["xsalsa20"]

--- a/salsa20/src/cipher.rs
+++ b/salsa20/src/cipher.rs
@@ -6,7 +6,7 @@
 
 use crate::{block::Block, rounds::Rounds, BLOCK_SIZE};
 use core::fmt;
-use stream_cipher::{LoopError, SyncStreamCipher, SyncStreamCipherSeek, SeekNum, OverflowError};
+use stream_cipher::{LoopError, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek};
 
 /// Internal buffer
 type Buffer = [u8; BLOCK_SIZE];
@@ -51,7 +51,7 @@ impl<R: Rounds> SyncStreamCipher for Cipher<R> {
                 let n = pos + data.len();
                 xor(data, &self.buffer[pos..n]);
                 self.buffer_pos = n as u8;
-                return Ok(())
+                return Ok(());
             } else {
                 let (l, r) = data.split_at_mut(BLOCK_SIZE - pos);
                 data = r;
@@ -69,7 +69,7 @@ impl<R: Rounds> SyncStreamCipher for Cipher<R> {
         let rem = chunks.into_remainder();
         self.buffer_pos = rem.len() as u8;
         self.counter = counter;
-        if rem.len() != 0 {
+        if !rem.is_empty() {
             self.block.generate(counter, &mut self.buffer);
             xor(rem, &self.buffer[..rem.len()]);
         }

--- a/salsa20/src/cipher.rs
+++ b/salsa20/src/cipher.rs
@@ -5,8 +5,8 @@
 // TODO(tarcieri): figure out how to unify this with the `ctr` crate (see #95)
 
 use crate::{block::Block, rounds::Rounds, BLOCK_SIZE};
-use core::{cmp, fmt};
-use stream_cipher::{LoopError, SyncStreamCipher, SyncStreamCipherSeek};
+use core::fmt;
+use stream_cipher::{LoopError, SyncStreamCipher, SyncStreamCipherSeek, SeekNum, OverflowError};
 
 /// Internal buffer
 type Buffer = [u8; BLOCK_SIZE];
@@ -20,7 +20,7 @@ pub(crate) struct Cipher<R: Rounds> {
     buffer: Buffer,
 
     /// Position within buffer, or `None` if the buffer is not in use
-    buffer_pos: Option<u8>,
+    buffer_pos: u8,
 
     /// Current counter value relative to the start of the keystream
     counter: u64,
@@ -32,7 +32,7 @@ impl<R: Rounds> Cipher<R> {
         Self {
             block,
             buffer: [0u8; BLOCK_SIZE],
-            buffer_pos: None,
+            buffer_pos: 0,
             counter: 0,
         }
     }
@@ -41,91 +41,68 @@ impl<R: Rounds> Cipher<R> {
 impl<R: Rounds> SyncStreamCipher for Cipher<R> {
     fn try_apply_keystream(&mut self, mut data: &mut [u8]) -> Result<(), LoopError> {
         self.check_data_len(data)?;
+        let pos = self.buffer_pos as usize;
+        debug_assert!(BLOCK_SIZE > pos);
 
+        let mut counter = self.counter;
         // xor with leftover bytes from the last call if any
-        if let Some(pos) = self.buffer_pos {
-            let pos = pos as usize;
-
-            if data.len() >= BLOCK_SIZE - pos {
-                let buf = &self.buffer[pos..];
-                let (r, l) = data.split_at_mut(buf.len());
-                data = l;
-                xor(r, buf);
-                self.buffer_pos = None;
+        if pos != 0 {
+            if data.len() < BLOCK_SIZE - pos {
+                let n = pos + data.len();
+                xor(data, &self.buffer[pos..n]);
+                self.buffer_pos = n as u8;
+                return Ok(())
             } else {
-                let buf = &self.buffer[pos..pos.checked_add(data.len()).unwrap()];
-                xor(data, buf);
-                self.buffer_pos = Some(pos.checked_add(data.len()).unwrap() as u8);
-                return Ok(());
+                let (l, r) = data.split_at_mut(BLOCK_SIZE - pos);
+                data = r;
+                xor(l, &self.buffer[pos..]);
+                counter += 1;
             }
         }
 
-        let mut counter = self.counter;
-
-        while data.len() >= BLOCK_SIZE {
-            let (l, r) = { data }.split_at_mut(BLOCK_SIZE);
-            data = r;
-            self.block.apply_keystream(counter, l);
-            counter = counter.checked_add(1).unwrap();
+        let mut chunks = data.chunks_exact_mut(BLOCK_SIZE);
+        for chunk in &mut chunks {
+            self.block.apply_keystream(counter, chunk);
+            counter += 1;
         }
 
-        if !data.is_empty() {
-            self.block.generate(counter, &mut self.buffer);
-            counter = counter.checked_add(1).unwrap();
-            let n = data.len();
-            xor(data, &self.buffer[..n]);
-            self.buffer_pos = Some(n as u8);
-        }
-
+        let rem = chunks.into_remainder();
+        self.buffer_pos = rem.len() as u8;
         self.counter = counter;
+        if rem.len() != 0 {
+            self.block.generate(counter, &mut self.buffer);
+            xor(rem, &self.buffer[..rem.len()]);
+        }
 
         Ok(())
     }
 }
 
 impl<R: Rounds> SyncStreamCipherSeek for Cipher<R> {
-    fn current_pos(&self) -> u64 {
-        let bs = BLOCK_SIZE as u64;
-
-        if let Some(pos) = self.buffer_pos {
-            (self.counter.wrapping_sub(1) * bs)
-                .checked_add(u64::from(pos))
-                .unwrap()
-        } else {
-            self.counter * bs
-        }
+    fn try_current_pos<T: SeekNum>(&self) -> Result<T, OverflowError> {
+        T::from_block_byte(self.counter, self.buffer_pos, BLOCK_SIZE as u8)
     }
 
-    fn seek(&mut self, pos: u64) {
-        let bs = BLOCK_SIZE as u64;
-        self.counter = pos / bs;
-        let rem = pos % bs;
-
-        if rem == 0 {
-            self.buffer_pos = None;
-        } else {
-            self.block.generate(self.counter, &mut self.buffer);
-            self.counter = self.counter.checked_add(1).unwrap();
-            self.buffer_pos = Some(rem as u8);
-        }
+    fn try_seek<T: SeekNum>(&mut self, pos: T) -> Result<(), LoopError> {
+        let res = pos.to_block_byte(BLOCK_SIZE as u8)?;
+        self.block.generate(self.counter, &mut self.buffer);
+        self.counter = res.0;
+        self.buffer_pos = res.1;
+        Ok(())
     }
 }
 
 impl<R: Rounds> Cipher<R> {
     fn check_data_len(&self, data: &[u8]) -> Result<(), LoopError> {
-        let dlen = data.len()
-            - self
-                .buffer_pos
-                .map(|pos| cmp::min(BLOCK_SIZE - pos as usize, data.len()))
-                .unwrap_or_default();
-
-        let data_blocks = dlen / BLOCK_SIZE + if data.len() % BLOCK_SIZE != 0 { 1 } else { 0 };
-
-        if self.counter.checked_add(data_blocks as u64).is_some() {
-            Ok(())
-        } else {
-            Err(LoopError)
+        let leftover_bytes = BLOCK_SIZE - self.buffer_pos as usize;
+        if data.len() < leftover_bytes {
+            return Ok(());
         }
+        let blocks = 1 + (data.len() - leftover_bytes) / BLOCK_SIZE;
+        self.counter
+            .checked_add(blocks as u64)
+            .ok_or(LoopError)
+            .map(|_| ())
     }
 }
 

--- a/salsa20/src/cipher.rs
+++ b/salsa20/src/cipher.rs
@@ -85,9 +85,11 @@ impl<R: Rounds> SyncStreamCipherSeek for Cipher<R> {
 
     fn try_seek<T: SeekNum>(&mut self, pos: T) -> Result<(), LoopError> {
         let res = pos.to_block_byte(BLOCK_SIZE as u8)?;
-        self.block.generate(self.counter, &mut self.buffer);
         self.counter = res.0;
         self.buffer_pos = res.1;
+        if self.buffer_pos != 0 {
+            self.block.generate(self.counter, &mut self.buffer);
+        }
         Ok(())
     }
 }

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -78,7 +78,7 @@ use crate::{
 use core::convert::TryInto;
 use stream_cipher::{
     consts::{U32, U8},
-    LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek, OverflowError, SeekNum,
+    LoopError, NewStreamCipher, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
 };
 
 /// Size of a Salsa20 block in bytes

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -76,8 +76,10 @@ use crate::{
     rounds::{Rounds, R12, R20, R8},
 };
 use core::convert::TryInto;
-use stream_cipher::consts::{U32, U8};
-use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
+use stream_cipher::{
+    consts::{U32, U8},
+    LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek, OverflowError, SeekNum,
+};
 
 /// Size of a Salsa20 block in bytes
 pub const BLOCK_SIZE: usize = 64;
@@ -139,12 +141,12 @@ impl<R: Rounds> NewStreamCipher for Salsa<R> {
 }
 
 impl<R: Rounds> SyncStreamCipherSeek for Salsa<R> {
-    fn current_pos(&self) -> u64 {
-        self.0.current_pos()
+    fn try_current_pos<T: SeekNum>(&self) -> Result<T, OverflowError> {
+        self.0.try_current_pos()
     }
 
-    fn seek(&mut self, pos: u64) {
-        self.0.seek(pos);
+    fn try_seek<T: SeekNum>(&mut self, pos: T) -> Result<(), LoopError> {
+        self.0.try_seek(pos)
     }
 }
 

--- a/salsa20/src/xsalsa20.rs
+++ b/salsa20/src/xsalsa20.rs
@@ -5,8 +5,8 @@ use core::convert::TryInto;
 use stream_cipher::{
     consts::{U16, U24, U32},
     generic_array::GenericArray,
+    LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek, OverflowError, SeekNum,
 };
-use stream_cipher::{LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
 
 /// EXtended Salsa20 nonce (192-bit/24-byte)
 #[cfg_attr(docsrs, doc(cfg(feature = "xsalsa20")))]
@@ -55,12 +55,12 @@ impl SyncStreamCipher for XSalsa20 {
 }
 
 impl SyncStreamCipherSeek for XSalsa20 {
-    fn current_pos(&self) -> u64 {
-        self.0.current_pos()
+    fn try_current_pos<T: SeekNum>(&self) -> Result<T, OverflowError> {
+        self.0.try_current_pos()
     }
 
-    fn seek(&mut self, pos: u64) {
-        self.0.seek(pos);
+    fn try_seek<T: SeekNum>(&mut self, pos: T) -> Result<(), LoopError> {
+        self.0.try_seek(pos)
     }
 }
 

--- a/salsa20/src/xsalsa20.rs
+++ b/salsa20/src/xsalsa20.rs
@@ -5,7 +5,7 @@ use core::convert::TryInto;
 use stream_cipher::{
     consts::{U16, U24, U32},
     generic_array::GenericArray,
-    LoopError, NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek, OverflowError, SeekNum,
+    LoopError, NewStreamCipher, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
 };
 
 /// EXtended Salsa20 nonce (192-bit/24-byte)

--- a/salsa20/tests/lib.rs
+++ b/salsa20/tests/lib.rs
@@ -4,7 +4,11 @@ use salsa20::Salsa20;
 #[cfg(feature = "xsalsa20")]
 use salsa20::XSalsa20;
 use stream_cipher::generic_array::GenericArray;
-use stream_cipher::{NewStreamCipher, StreamCipher, SyncStreamCipherSeek};
+use stream_cipher::{NewStreamCipher, StreamCipher, SyncStreamCipherSeek, new_seek_test};
+
+new_seek_test!(salsa20_seek, Salsa20);
+#[cfg(feature = "xsalsa20")]
+new_seek_test!(xsalsa20_seek, XSalsa20);
 
 #[cfg(test)]
 const KEY_BYTES: usize = 32;

--- a/salsa20/tests/lib.rs
+++ b/salsa20/tests/lib.rs
@@ -4,7 +4,7 @@ use salsa20::Salsa20;
 #[cfg(feature = "xsalsa20")]
 use salsa20::XSalsa20;
 use stream_cipher::generic_array::GenericArray;
-use stream_cipher::{NewStreamCipher, StreamCipher, SyncStreamCipherSeek, new_seek_test};
+use stream_cipher::{new_seek_test, NewStreamCipher, StreamCipher, SyncStreamCipherSeek};
 
 new_seek_test!(salsa20_seek, Salsa20);
 #[cfg(feature = "xsalsa20")]


### PR DESCRIPTION
Mostly changes around the new seek trait, plus some improvements of the code for `ctr` and `salsa20`/`chacha20`.

TODO:
- [x] upgrade `aesni`
- [x] fix `chacha20` on AVX2

@tarcieri 
Can you please check the `salsa20` and `chacha20` changes, especially the latter one? Tests do pass, but I am not 100% confident about changes (and with salsa one mistake almost got through, if not for the single "hello world" test). Note that I've removed the `Option` and instead code now assumes that if buffer position is equal to 0, then the cached buffer is invalid.