### PR TITLE
ctr v0.6.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.5.0"
+version = "0.6.0-pre"
 dependencies = [
  "aes",
  "hex-literal",

--- a/aes-ctr/Cargo.toml
+++ b/aes-ctr/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 stream-cipher = "0.8.0-pre"
 
 [target.'cfg(not(all(target_feature = "aes", target_feature = "sse2", target_feature = "ssse3", any(target_arch = "x86_64", target_arch = "x86"))))'.dependencies]
-ctr = { version = "0.5", path = "../ctr" }
+ctr = { version = "0.6.0-pre", path = "../ctr" }
 aes-soft = "0.5"
 
 [target.'cfg(all(target_feature = "aes", target_feature = "sse2", target_feature = "ssse3", any(target_arch = "x86_64", target_arch = "x86")))'.dependencies]

--- a/ctr/CHANGELOG.md
+++ b/ctr/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0-pre (2020-10-14)
+### Added
+- `Ctr32BE` and `Ctr32LE` ([#170])
+
+[#170]: https://github.com/RustCrypto/stream-ciphers/pull/170
+
 ## 0.5.0 (2020-08-26)
 ### Changed
 - Bump `stream-cipher` dependency to v0.7, implement the `FromBlockCipher` trait ([#161], [#164])

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctr"
-version = "0.5.0"
+version = "0.6.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "CTR block mode of operation"


### PR DESCRIPTION
### Added
- `Ctr32BE` and `Ctr32LE` ([#170])

[#170]: https://github.com/RustCrypto/stream-ciphers/pull/170