### PR TITLE
Replace `block-cipher`/`stream-cipher` with `cipher` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,55 +2,44 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aes"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2bc6d3f370b5666245ff421e231cba4353df936e26986d2918e61a8fd6aef6"
+checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
 dependencies = [
  "aes-soft",
- "aesni 0.8.0",
- "block-cipher",
+ "aesni",
+ "cipher",
 ]
 
 [[package]]
 name = "aes-ctr"
-version = "0.5.0"
+version = "0.6.0-pre"
 dependencies = [
  "aes-soft",
- "aesni 0.9.0",
+ "aesni",
+ "cipher",
  "ctr",
- "stream-cipher 0.8.0-pre",
 ]
 
 [[package]]
 name = "aes-soft"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
+checksum = "8c5ab1fa47ce0ddf44cbd65b1b4e626e3c03b06fd42005603acdc6fa13526296"
 dependencies = [
- "block-cipher",
  "byteorder",
+ "cipher",
  "opaque-debug",
 ]
 
 [[package]]
 name = "aesni"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6fe808308bb07d393e2ea47780043ec47683fcf19cf5efc8ca51c50cc8c68a"
+checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
 dependencies = [
- "block-cipher",
+ "cipher",
  "opaque-debug",
-]
-
-[[package]]
-name = "aesni"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a4d655ae633a96d0acaf0fd7e76aafb8ca5732739bba37aac6f882c8fce656"
-dependencies = [
- "block-cipher",
- "opaque-debug",
- "stream-cipher 0.7.1",
 ]
 
 [[package]]
@@ -60,15 +49,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc52553543ecb104069b0ff9e0fcc5c739ad16202935528a112d974e8f1a4ee8"
 
 [[package]]
-name = "block-cipher"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,30 +56,40 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cfb-mode"
-version = "0.5.0"
+version = "0.6.0-pre"
 dependencies = [
  "aes",
+ "cipher",
  "hex-literal",
- "stream-cipher 0.7.1",
 ]
 
 [[package]]
 name = "cfb8"
-version = "0.5.0"
+version = "0.6.0-pre"
 dependencies = [
  "aes",
+ "cipher",
  "hex-literal",
- "stream-cipher 0.7.1",
 ]
 
 [[package]]
 name = "chacha20"
-version = "0.5.0"
+version = "0.6.0-pre"
 dependencies = [
+ "cipher",
  "hex-literal",
  "rand_core",
- "stream-cipher 0.7.1",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f7954ae5588102b35257639b1c36a2e7425cc6540fcdb4de19dcb91055d659"
+dependencies = [
+ "blobby",
+ "generic-array",
 ]
 
 [[package]]
@@ -107,8 +97,8 @@ name = "ctr"
 version = "0.6.0-pre"
 dependencies = [
  "aes",
+ "cipher",
  "hex-literal",
- "stream-cipher 0.8.0-pre",
 ]
 
 [[package]]
@@ -123,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "hc-256"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
- "stream-cipher 0.7.1",
+ "cipher",
  "zeroize",
 ]
 
@@ -150,11 +140,11 @@ dependencies = [
 
 [[package]]
 name = "ofb"
-version = "0.3.0"
+version = "0.4.0-pre"
 dependencies = [
  "aes",
+ "cipher",
  "hex-literal",
- "stream-cipher 0.7.1",
 ]
 
 [[package]]
@@ -177,32 +167,10 @@ checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "salsa20"
-version = "0.6.0"
+version = "0.7.0-pre"
 dependencies = [
- "stream-cipher 0.7.1",
+ "cipher",
  "zeroize",
-]
-
-[[package]]
-name = "stream-cipher"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80e15f898d8d8f25db24c253ea615cc14acf418ff307822995814e7d42cfa89"
-dependencies = [
- "blobby",
- "block-cipher",
- "generic-array",
-]
-
-[[package]]
-name = "stream-cipher"
-version = "0.8.0-pre"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c22786b7392254461cf5f358c143035828bf5d95850d4adc483faf065f5b9e"
-dependencies = [
- "blobby",
- "block-cipher",
- "generic-array",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ done with a minor version bump.
 
 ## Usage
 
-Crates functionality is expressed in terms of traits defined in the
-[`stream-cipher`][2] crate.
+Crates functionality is expressed in terms of traits defined in the [`cipher`][2] crate.
 
 Let's use AES-128-OFB to demonstrate usage of synchronous stream cipher:
 
@@ -44,7 +43,7 @@ use aes::Aes128;
 use ofb::Ofb;
 
 // import relevant traits
-use ofb::stream_cipher::{NewStreamCipher, SyncStreamCipher};
+use ofb::cipher::{NewStreamCipher, SyncStreamCipher};
 
 // OFB mode implementation is generic over block ciphers
 // we will create a type alias for convenience
@@ -98,7 +97,7 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (footnotes)
 
 [1]: https://en.wikipedia.org/wiki/Stream_cipher
-[2]: https://docs.rs/stream-cipher
+[2]: https://docs.rs/cipher
 
 [//]: # (crates)
 

--- a/aes-ctr/Cargo.toml
+++ b/aes-ctr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-ctr"
-version = "0.5.0"
+version = "0.6.0-pre"
 description = "AES-CTR stream ciphers"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,14 +12,14 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = "0.8.0-pre"
+cipher = "0.2"
 
 [target.'cfg(not(all(target_feature = "aes", target_feature = "sse2", target_feature = "ssse3", any(target_arch = "x86_64", target_arch = "x86"))))'.dependencies]
 ctr = { version = "0.6.0-pre", path = "../ctr" }
-aes-soft = "0.5"
+aes-soft = "0.6"
 
 [target.'cfg(all(target_feature = "aes", target_feature = "sse2", target_feature = "ssse3", any(target_arch = "x86_64", target_arch = "x86")))'.dependencies]
-aesni = "0.9"
+aesni = "0.10"
 
 [dev-dependencies]
-stream-cipher = { version = "0.8.0-pre", features = ["dev"] }
+cipher = { version = "0.2", features = ["dev"] }

--- a/aes-ctr/benches/aes128_ctr.rs
+++ b/aes-ctr/benches/aes128_ctr.rs
@@ -1,3 +1,3 @@
 #![feature(test)]
 
-stream_cipher::bench_sync!(aes_ctr::Aes128Ctr);
+cipher::bench_sync!(aes_ctr::Aes128Ctr);

--- a/aes-ctr/benches/aes192_ctr.rs
+++ b/aes-ctr/benches/aes192_ctr.rs
@@ -1,3 +1,3 @@
 #![feature(test)]
 
-stream_cipher::bench_sync!(aes_ctr::Aes192Ctr);
+cipher::bench_sync!(aes_ctr::Aes192Ctr);

--- a/aes-ctr/benches/aes256_ctr.rs
+++ b/aes-ctr/benches/aes256_ctr.rs
@@ -1,3 +1,3 @@
 #![feature(test)]
 
-stream_cipher::bench_sync!(aes_ctr::Aes128Ctr);
+cipher::bench_sync!(aes_ctr::Aes128Ctr);

--- a/aes-ctr/src/lib.rs
+++ b/aes-ctr/src/lib.rs
@@ -1,7 +1,7 @@
 //! AES-CTR ciphers implementation.
 //!
 //! Cipher functionality is accessed using traits from re-exported
-//! [`stream-cipher`](https://docs.rs/stream-cipher) crate.
+//! [`cipher`](https://docs.rs/cipher) crate.
 //!
 //! This crate will select appropriate implementation at compile time depending
 //! on target architecture and enabled target features. For the best performance
@@ -16,9 +16,11 @@
 //! # Usage example
 //! ```
 //! use aes_ctr::Aes128Ctr;
-//! use aes_ctr::stream_cipher::generic_array::GenericArray;
-//! use aes_ctr::stream_cipher::{
-//!     NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek
+//! use aes_ctr::cipher::{
+//!     generic_array::GenericArray,
+//!     stream::{
+//!         NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek
+//!     }
 //! };
 //!
 //! let mut data = [1, 2, 3, 4, 5, 6, 7];
@@ -45,7 +47,7 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![warn(missing_docs, rust_2018_idioms)]
 
-pub use stream_cipher;
+pub use cipher;
 
 #[cfg(not(all(
     target_feature = "aes",

--- a/aes-ctr/tests/lib.rs
+++ b/aes-ctr/tests/lib.rs
@@ -1,9 +1,8 @@
 #![no_std]
 
 use aes_ctr::{Aes128Ctr, Aes256Ctr};
-use stream_cipher::{new_seek_test, new_sync_test};
 
-new_sync_test!(aes128_ctr_core, Aes128Ctr, "aes128-ctr");
-new_sync_test!(aes256_ctr_core, Aes256Ctr, "aes256-ctr");
-new_seek_test!(aes128_ctr_seek, Aes128Ctr);
-new_seek_test!(aes256_ctr_seek, Aes256Ctr);
+cipher::new_sync_test!(aes128_ctr_core, Aes128Ctr, "aes128-ctr");
+cipher::new_sync_test!(aes256_ctr_core, Aes256Ctr, "aes256-ctr");
+cipher::new_seek_test!(aes128_ctr_seek, Aes128Ctr);
+cipher::new_seek_test!(aes256_ctr_seek, Aes256Ctr);

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dev-dependencies]
 criterion = "0.3"
 criterion-cycles-per-byte = "0.1"
-chacha20 = { path = "../chacha20/", features = ["stream-cipher"] }
+chacha20 = { path = "../chacha20/", features = ["cipher"] }
 
 [[bench]]
 name = "chacha20"

--- a/benches/src/chacha20.rs
+++ b/benches/src/chacha20.rs
@@ -3,7 +3,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
 use criterion_cycles_per_byte::CyclesPerByte;
 
 use chacha20::{
-    stream_cipher::{NewStreamCipher, SyncStreamCipher},
+    cipher::{NewStreamCipher, SyncStreamCipher},
     ChaCha20,
 };
 

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfb-mode"
-version = "0.5.0"
+version = "0.6.0-pre"
 description = "Generic Cipher Feedback (CFB) mode implementation."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = { version = "0.7", features = ["block-cipher"] }
+cipher = "0.2"
 
 [dev-dependencies]
-aes = "0.5"
-stream-cipher = { version = "0.7", features = ["dev"] }
+aes = "0.6"
+cipher = { version = "0.2", features = ["dev"] }
 hex-literal = "0.2"

--- a/cfb-mode/benches/cfb-mode.rs
+++ b/cfb-mode/benches/cfb-mode.rs
@@ -1,3 +1,3 @@
 #![feature(test)]
 
-stream_cipher::bench_async!(cfb_mode::Cfb<aes::Aes128>);
+cipher::bench_async!(cfb_mode::Cfb<aes::Aes128>);

--- a/cfb-mode/src/lib.rs
+++ b/cfb-mode/src/lib.rs
@@ -10,7 +10,7 @@
 //! ```
 //! use aes::Aes128;
 //! use cfb_mode::Cfb;
-//! use cfb_mode::stream_cipher::{NewStreamCipher, StreamCipher};
+//! use cfb_mode::cipher::{NewStreamCipher, StreamCipher};
 //! use hex_literal::hex;
 //!
 //! type AesCfb = Cfb<Aes128>;
@@ -50,13 +50,14 @@
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 
-pub use stream_cipher;
+pub use cipher;
 
+use cipher::{
+    block::{BlockCipher, NewBlockCipher, ParBlocks},
+    generic_array::{typenum::Unsigned, GenericArray},
+    stream::{FromBlockCipher, StreamCipher},
+};
 use core::slice;
-use stream_cipher::block_cipher::{BlockCipher, NewBlockCipher};
-use stream_cipher::generic_array::typenum::Unsigned;
-use stream_cipher::generic_array::GenericArray;
-use stream_cipher::{FromBlockCipher, StreamCipher};
 
 /// CFB self-synchronizing stream cipher instance.
 pub struct Cfb<C: BlockCipher> {
@@ -64,9 +65,6 @@ pub struct Cfb<C: BlockCipher> {
     iv: GenericArray<u8, C::BlockSize>,
     pos: usize,
 }
-
-type Block<C> = GenericArray<u8, <C as BlockCipher>::BlockSize>;
-type ParBlocks<C> = GenericArray<Block<C>, <C as BlockCipher>::ParBlocks>;
 
 impl<C> FromBlockCipher for Cfb<C>
 where

--- a/cfb-mode/tests/lib.rs
+++ b/cfb-mode/tests/lib.rs
@@ -1,8 +1,7 @@
 use cfb_mode::Cfb;
-use stream_cipher::new_async_test;
 
 // tests vectors are from:
 // https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf
-new_async_test!(cfb_aes128, "aes128", Cfb<aes::Aes128>);
-new_async_test!(cfb_aes192, "aes192", Cfb<aes::Aes192>);
-new_async_test!(cfb_aes256, "aes256", Cfb<aes::Aes256>);
+cipher::new_async_test!(cfb_aes128, "aes128", Cfb<aes::Aes128>);
+cipher::new_async_test!(cfb_aes192, "aes192", Cfb<aes::Aes192>);
+cipher::new_async_test!(cfb_aes256, "aes256", Cfb<aes::Aes256>);

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfb8"
-version = "0.5.0"
+version = "0.6.0-pre"
 description = "Generic 8-bit Cipher Feedback (CFB8) mode implementation."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = { version = "0.7", features = ["block-cipher"] }
+cipher = "0.2"
 
 [dev-dependencies]
-aes = "0.5"
-stream-cipher = { version = "0.7", features = ["dev"] }
+aes = "0.6"
+cipher = { version = "0.2", features = ["dev"] }
 hex-literal = "0.2"

--- a/cfb8/benches/cfb8.rs
+++ b/cfb8/benches/cfb8.rs
@@ -1,3 +1,3 @@
 #![feature(test)]
 
-stream_cipher::bench_async!(cfb8::Cfb8<aes::Aes128>);
+cipher::bench_async!(cfb8::Cfb8<aes::Aes128>);

--- a/cfb8/src/lib.rs
+++ b/cfb8/src/lib.rs
@@ -10,7 +10,7 @@
 //! ```
 //! use aes::Aes128;
 //! use cfb8::Cfb8;
-//! use cfb8::stream_cipher::{NewStreamCipher, StreamCipher};
+//! use cfb8::cipher::{NewStreamCipher, StreamCipher};
 //! use hex_literal::hex;
 //!
 //! type AesCfb8 = Cfb8<Aes128>;
@@ -51,11 +51,13 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
-pub use stream_cipher;
+pub use cipher;
 
-use stream_cipher::block_cipher::{BlockCipher, NewBlockCipher};
-use stream_cipher::generic_array::GenericArray;
-use stream_cipher::{FromBlockCipher, StreamCipher};
+use cipher::{
+    block::{BlockCipher, NewBlockCipher},
+    generic_array::GenericArray,
+    stream::{FromBlockCipher, Nonce, StreamCipher},
+};
 
 /// CFB self-synchronizing stream cipher instance.
 pub struct Cfb8<C: BlockCipher> {
@@ -70,7 +72,7 @@ where
     type BlockCipher = C;
     type NonceSize = C::BlockSize;
 
-    fn from_block_cipher(cipher: C, iv: &GenericArray<u8, Self::NonceSize>) -> Self {
+    fn from_block_cipher(cipher: C, iv: &Nonce<Self>) -> Self {
         Self {
             cipher,
             iv: iv.clone(),

--- a/cfb8/tests/lib.rs
+++ b/cfb8/tests/lib.rs
@@ -1,8 +1,7 @@
 use cfb8::Cfb8;
-use stream_cipher::new_async_test;
 
 // tests vectors are from:
 // https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf
-new_async_test!(cfb8_aes128, "aes128", Cfb8<aes::Aes128>);
-new_async_test!(cfb8_aes192, "aes192", Cfb8<aes::Aes192>);
-new_async_test!(cfb8_aes256, "aes256", Cfb8<aes::Aes256>);
+cipher::new_async_test!(cfb8_aes128, "aes128", Cfb8<aes::Aes128>);
+cipher::new_async_test!(cfb8_aes192, "aes192", Cfb8<aes::Aes192>);
+cipher::new_async_test!(cfb8_aes256, "aes256", Cfb8<aes::Aes256>);

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.5.0"
+version = "0.6.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -17,18 +17,18 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
+cipher = { version = "0.2", optional = true }
 rand_core = { version = "0.5", optional = true, default-features = false }
-stream-cipher = { version = "0.7", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-stream-cipher = { version = "0.7", features = ["dev"] }
+cipher = { version = "0.2", features = ["dev"] }
 hex-literal = "0.2"
 
 [features]
 default = ["xchacha20"]
-legacy = ["stream-cipher"]
-xchacha20 = ["stream-cipher"]
+legacy = ["cipher"]
+xchacha20 = ["cipher"]
 rng = ["rand_core"]
 
 [package.metadata.docs.rs]

--- a/chacha20/benches/chacha12.rs
+++ b/chacha20/benches/chacha12.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "stream-cipher")]
+#![cfg(feature = "cipher")]
 #![feature(test)]
 
-stream_cipher::bench_sync!(chacha20::ChaCha12);
+cipher::bench_sync!(chacha20::ChaCha12);

--- a/chacha20/benches/chacha20.rs
+++ b/chacha20/benches/chacha20.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "stream-cipher")]
+#![cfg(feature = "cipher")]
 #![feature(test)]
 
-stream_cipher::bench_sync!(chacha20::ChaCha20);
+cipher::bench_sync!(chacha20::ChaCha20);

--- a/chacha20/benches/chacha8.rs
+++ b/chacha20/benches/chacha8.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "stream-cipher")]
+#![cfg(feature = "cipher")]
 #![feature(test)]
 
-stream_cipher::bench_sync!(chacha20::ChaCha8);
+cipher::bench_sync!(chacha20::ChaCha8);

--- a/chacha20/src/block/avx2.rs
+++ b/chacha20/src/block/avx2.rs
@@ -61,7 +61,7 @@ impl<R: Rounds> Block<R> {
     }
 
     #[inline]
-    #[cfg(feature = "stream-cipher")]
+    #[cfg(feature = "cipher")]
     #[allow(clippy::cast_ptr_alignment)] // loadu/storeu support unaligned loads/stores
     pub(crate) fn apply_keystream(&self, counter: u64, output: &mut [u8]) {
         debug_assert_eq!(output.len(), BUFFER_SIZE);

--- a/chacha20/src/block/soft.rs
+++ b/chacha20/src/block/soft.rs
@@ -68,7 +68,7 @@ impl<R: Rounds> Block<R> {
 
     /// Apply generated keystream to the output buffer
     #[inline]
-    #[cfg(feature = "stream-cipher")]
+    #[cfg(feature = "cipher")]
     pub(crate) fn apply_keystream(&mut self, counter: u64, output: &mut [u8]) {
         debug_assert_eq!(output.len(), BUFFER_SIZE);
         self.counter_setup(counter);

--- a/chacha20/src/block/sse2.rs
+++ b/chacha20/src/block/sse2.rs
@@ -58,7 +58,7 @@ impl<R: Rounds> Block<R> {
     }
 
     #[inline]
-    #[cfg(feature = "stream-cipher")]
+    #[cfg(feature = "cipher")]
     #[allow(clippy::cast_ptr_alignment)] // loadu/storeu support unaligned loads/stores
     pub(crate) fn apply_keystream(&self, counter: u64, output: &mut [u8]) {
         debug_assert_eq!(output.len(), BUFFER_SIZE);

--- a/chacha20/src/chacha.rs
+++ b/chacha20/src/chacha.rs
@@ -9,35 +9,38 @@ use crate::{
     rounds::{Rounds, R12, R20, R8},
     BLOCK_SIZE, MAX_BLOCKS,
 };
+use cipher::stream::{
+    consts::{U12, U32},
+    LoopError, NewStreamCipher, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
+};
 use core::{
     convert::TryInto,
     fmt::{self, Debug},
 };
-use stream_cipher::{
-    consts::{U12, U32},
-    LoopError, NewStreamCipher, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
-};
+
+#[cfg(docsrs)]
+use cipher::generic_array::GenericArray;
 
 /// ChaCha8 stream cipher (reduced-round variant of ChaCha20 with 8 rounds)
-pub type ChaCha8 = Cipher<R8>;
+pub type ChaCha8 = ChaCha<R8>;
 
 /// ChaCha12 stream cipher (reduced-round variant of ChaCha20 with 12 rounds)
-pub type ChaCha12 = Cipher<R12>;
+pub type ChaCha12 = ChaCha<R12>;
 
 /// ChaCha20 stream cipher (RFC 8439 version with 96-bit nonce)
-pub type ChaCha20 = Cipher<R20>;
+pub type ChaCha20 = ChaCha<R20>;
 
 /// ChaCha20 key type (256-bits/32-bytes)
 ///
 /// Implemented as an alias for [`GenericArray`].
 ///
 /// (NOTE: all variants of [`ChaCha20`] including `XChaCha20` use the same key type)
-pub type Key = stream_cipher::Key<ChaCha20>;
+pub type Key = cipher::stream::Key<ChaCha20>;
 
 /// Nonce type (96-bits/12-bytes)
 ///
 /// Implemented as an alias for [`GenericArray`].
-pub type Nonce = stream_cipher::Nonce<ChaCha20>;
+pub type Nonce = cipher::stream::Nonce<ChaCha20>;
 
 /// Internal buffer
 type Buffer = [u8; BUFFER_SIZE];
@@ -54,7 +57,7 @@ const COUNTER_INCR: u64 = (BUFFER_SIZE as u64) / (BLOCK_SIZE as u64);
 /// a specific number of rounds.
 ///
 /// Generally [`ChaCha20`] is preferred.
-pub struct Cipher<R: Rounds> {
+pub struct ChaCha<R: Rounds> {
     /// ChaCha20 block function initialized with a key and IV
     block: Block<R>,
 
@@ -73,7 +76,7 @@ pub struct Cipher<R: Rounds> {
     counter_offset: u64,
 }
 
-impl<R: Rounds> NewStreamCipher for Cipher<R> {
+impl<R: Rounds> NewStreamCipher for ChaCha<R> {
     /// Key size in bytes
     type KeySize = U32;
 
@@ -101,7 +104,7 @@ impl<R: Rounds> NewStreamCipher for Cipher<R> {
     }
 }
 
-impl<R: Rounds> SyncStreamCipher for Cipher<R> {
+impl<R: Rounds> SyncStreamCipher for ChaCha<R> {
     fn try_apply_keystream(&mut self, mut data: &mut [u8]) -> Result<(), LoopError> {
         self.check_data_len(data)?;
         let pos = self.buffer_pos as usize;
@@ -142,7 +145,7 @@ impl<R: Rounds> SyncStreamCipher for Cipher<R> {
     }
 }
 
-impl<R: Rounds> SyncStreamCipherSeek for Cipher<R> {
+impl<R: Rounds> SyncStreamCipherSeek for ChaCha<R> {
     fn try_current_pos<T: SeekNum>(&self) -> Result<T, OverflowError> {
         // quick and dirty fix, until ctr-like parallel block processing will be added
         let (counter, pos) = if self.buffer_pos < BLOCK_SIZE as u8 {
@@ -167,7 +170,7 @@ impl<R: Rounds> SyncStreamCipherSeek for Cipher<R> {
     }
 }
 
-impl<R: Rounds> Cipher<R> {
+impl<R: Rounds> ChaCha<R> {
     /// Check data length
     fn check_data_len(&self, data: &[u8]) -> Result<(), LoopError> {
         let leftover_bytes = BUFFER_SIZE - self.buffer_pos as usize;
@@ -192,7 +195,7 @@ impl<R: Rounds> Cipher<R> {
     }
 }
 
-impl<R: Rounds> Debug for Cipher<R> {
+impl<R: Rounds> Debug for ChaCha<R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "Cipher {{ .. }}")
     }

--- a/chacha20/src/legacy.rs
+++ b/chacha20/src/legacy.rs
@@ -1,14 +1,14 @@
 //! Legacy version of ChaCha20 with a 64-bit nonce
 
-use crate::cipher::{ChaCha20, Key};
-use stream_cipher::{
+use crate::chacha::{ChaCha20, Key};
+use cipher::stream::{
     consts::{U32, U8},
     LoopError, NewStreamCipher, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
 };
 
 /// Size of the nonce for the legacy ChaCha20 stream cipher
 #[cfg_attr(docsrs, doc(cfg(feature = "legacy")))]
-pub type LegacyNonce = stream_cipher::Nonce<ChaCha20Legacy>;
+pub type LegacyNonce = cipher::stream::Nonce<ChaCha20Legacy>;
 
 /// The ChaCha20 stream cipher (legacy "djb" construction with 64-bit nonce).
 ///

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -6,21 +6,24 @@
 //! with no cost to performance.
 //!
 //! Cipher functionality is accessed using traits from re-exported
-//! [`stream-cipher`](https://docs.rs/stream-cipher) crate.
+//! [`cipher`](https://docs.rs/cipher) crate.
 //!
-//! This crate contains three variants of ChaCha20:
+//! This crate contains the following variants of the ChaCha20 core algorithm:
 //!
-//! - `ChaCha20`: standard IETF variant with 96-bit nonce
-//! - `ChaCha20Legacy`: (gated under the `legacy` feature) "djb" variant with 64-bit nonce
-//! - `ChaCha8` / `ChaCha12`: reduced round variants of ChaCha20
-//! - `XChaCha20`: (gated under the `xchacha20` feature) 192-bit extended nonce variant
+//! - [`ChaCha20`]: standard IETF variant with 96-bit nonce
+//! - [`ChaCha20Legacy`]: (gated under the `legacy` feature) "djb" variant with 64-bit nonce
+//! - [`ChaCha8`] / [`ChaCha12`]: reduced round variants of ChaCha20
+//! - [`XChaCha20`]: (gated under the `xchacha20` feature) 192-bit extended nonce variant
 //!
-//! # Security Warning
+//! # ⚠️ Security Warning: [Hazmat!]
 //!
 //! This crate does not ensure ciphertexts are authentic, which can lead to
 //! serious vulnerabilities if used incorrectly!
 //!
-//! USE AT YOUR OWN RISK!
+//! If in doubt, use the [`chacha20poly1305`](https://docs.rs/chacha20poly1305)
+//! crate instead, which provides an authenticated mode on top of ChaCha20.
+//!
+//! **USE AT YOUR OWN RISK!**
 //!
 //! # Diagram
 //!
@@ -39,7 +42,7 @@
 //!
 //! ```
 //! use chacha20::{ChaCha20, Key, Nonce};
-//! use chacha20::stream_cipher::{NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
+//! use chacha20::cipher::{NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
 //!
 //! let mut data = [1, 2, 3, 4, 5, 6, 7];
 //!
@@ -61,6 +64,7 @@
 //!
 //! [RFC 8439]: https://tools.ietf.org/html/rfc8439
 //! [Salsa20]: https://docs.rs/salsa20
+//! [Hazmat!]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 
 #![no_std]
 #![doc(
@@ -71,21 +75,21 @@
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
 
 mod block;
-#[cfg(feature = "stream-cipher")]
-pub(crate) mod cipher;
+#[cfg(feature = "cipher")]
+mod chacha;
 #[cfg(feature = "legacy")]
 mod legacy;
 #[cfg(feature = "rng")]
 mod rng;
 mod rounds;
 #[cfg(feature = "xchacha20")]
-mod xchacha20;
+mod xchacha;
 
-#[cfg(feature = "stream-cipher")]
-pub use stream_cipher;
+#[cfg(feature = "cipher")]
+pub use cipher;
 
-#[cfg(feature = "stream-cipher")]
-pub use self::cipher::{ChaCha12, ChaCha20, ChaCha8, Cipher, Key, Nonce};
+#[cfg(feature = "cipher")]
+pub use self::chacha::{ChaCha, ChaCha12, ChaCha20, ChaCha8, Key, Nonce};
 
 #[cfg(feature = "legacy")]
 pub use self::legacy::{ChaCha20Legacy, LegacyNonce};
@@ -96,7 +100,7 @@ pub use rng::{
 };
 
 #[cfg(feature = "xchacha20")]
-pub use self::xchacha20::{XChaCha20, XNonce};
+pub use self::xchacha::{XChaCha20, XNonce};
 
 /// Size of a ChaCha20 block in bytes
 pub const BLOCK_SIZE: usize = 64;

--- a/chacha20/src/xchacha.rs
+++ b/chacha20/src/xchacha.rs
@@ -2,19 +2,21 @@
 
 use crate::{
     block::soft::quarter_round,
-    cipher::{ChaCha20, Key},
+    chacha::{ChaCha20, Key},
     CONSTANTS,
 };
-use core::convert::TryInto;
-use stream_cipher::{
+use cipher::{
     consts::{U16, U24, U32},
     generic_array::GenericArray,
-    LoopError, NewStreamCipher, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
+    stream::{
+        LoopError, NewStreamCipher, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
+    },
 };
+use core::convert::TryInto;
 
 /// EXtended ChaCha20 nonce (192-bits/24-bytes)
 #[cfg_attr(docsrs, doc(cfg(feature = "xchacha20")))]
-pub type XNonce = stream_cipher::Nonce<XChaCha20>;
+pub type XNonce = cipher::stream::Nonce<XChaCha20>;
 
 /// XChaCha20 is a ChaCha20 variant with an extended 192-bit (24-byte) nonce.
 ///

--- a/chacha20/tests/lib.rs
+++ b/chacha20/tests/lib.rs
@@ -1,21 +1,19 @@
 //! Tests for ChaCha20 (IETF and "djb" versions) as well as XChaCha20
 
 use chacha20::ChaCha20;
-use stream_cipher::{new_seek_test, new_sync_test};
 
 // IETF version of ChaCha20 (96-bit nonce)
-new_sync_test!(chacha20_core, ChaCha20, "chacha20");
-new_seek_test!(chacha20_seek, ChaCha20);
+cipher::new_sync_test!(chacha20_core, ChaCha20, "chacha20");
+cipher::new_seek_test!(chacha20_seek, ChaCha20);
 
 #[cfg(feature = "xchacha20")]
 #[rustfmt::skip]
 mod xchacha20 {
     use chacha20::{Key, XChaCha20, XNonce};
-    use stream_cipher::{NewStreamCipher, StreamCipher};
+    use cipher::stream::{NewStreamCipher, StreamCipher};
     use hex_literal::hex;
-    use stream_cipher::new_seek_test;
 
-    new_seek_test!(xchacha20_seek, XChaCha20);
+    cipher::new_seek_test!(xchacha20_seek, XChaCha20);
 
     //
     // XChaCha20 test vectors from:
@@ -101,12 +99,11 @@ mod xchacha20 {
 #[rustfmt::skip]
 mod legacy {
     use chacha20::{ChaCha20Legacy, Key, LegacyNonce};
-    use stream_cipher::{new_seek_test, new_sync_test};
-    use stream_cipher::{NewStreamCipher, StreamCipher, SyncStreamCipherSeek};
+    use cipher::stream::{NewStreamCipher, StreamCipher, SyncStreamCipherSeek};
     use hex_literal::hex;
 
-    new_sync_test!(chacha20_legacy_core, ChaCha20Legacy, "chacha20-legacy");
-    new_seek_test!(chacha20_legacy_seek, ChaCha20Legacy);
+    cipher::new_sync_test!(chacha20_legacy_core, ChaCha20Legacy, "chacha20-legacy");
+    cipher::new_seek_test!(chacha20_legacy_seek, ChaCha20Legacy);
 
     const KEY_LONG: [u8; 32] = hex!("
         0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = { version = "0.8.0-pre", features = ["block-cipher"] }
+cipher = "0.2"
 
 [dev-dependencies]
-aes = "0.5"
+aes = "0.6"
 hex-literal = "0.2"
-stream-cipher = { version = "0.8.0-pre", features = ["block-cipher", "dev"] }
+cipher = { version = "0.2", features = ["dev"] }

--- a/ctr/benches/aes128.rs
+++ b/ctr/benches/aes128.rs
@@ -1,3 +1,3 @@
 #![feature(test)]
 
-stream_cipher::bench_sync!(ctr::Ctr128<aes::Aes128>);
+cipher::bench_sync!(ctr::Ctr128<aes::Aes128>);

--- a/ctr/src/ctr32.rs
+++ b/ctr/src/ctr32.rs
@@ -1,16 +1,12 @@
 //! Generic implementation of CTR mode with a 32-bit counter
 //! (big or little endian), generic over block ciphers.
 
-use core::{convert::TryInto, marker::PhantomData, mem};
-use stream_cipher::{
-    block_cipher::{Block, BlockCipher},
+use cipher::{
+    block::{Block, BlockCipher, ParBlocks},
     generic_array::{typenum::Unsigned, ArrayLength, GenericArray},
-    FromBlockCipher, LoopError, SyncStreamCipher,
+    stream::{FromBlockCipher, LoopError, SyncStreamCipher},
 };
-
-/// Internal buffer for a given block cipher
-type BlockBuffer<B> = GenericArray<Block<B>, <B as BlockCipher>::ParBlocks>;
-
+use core::{convert::TryInto, marker::PhantomData, mem};
 /// CTR mode with a 32-bit big endian counter.
 ///
 /// Used by e.g. AES-GCM.
@@ -72,7 +68,7 @@ where
     }
 }
 
-/// Implement `stream-cipher` traits for the given `Ctr32*` type
+/// Implement stream cipher traits for the given `Ctr32*` type
 macro_rules! impl_ctr32 {
     ($ctr32:tt) => {
         impl<B> SyncStreamCipher for $ctr32<B>
@@ -130,7 +126,7 @@ where
     cipher: B,
 
     /// Keystream buffer
-    buffer: BlockBuffer<B>,
+    buffer: ParBlocks<B>,
 
     /// Current CTR value
     counter_block: Block<B>,

--- a/ctr/src/lib.rs
+++ b/ctr/src/lib.rs
@@ -1,29 +1,29 @@
 //! Generic implementations of CTR mode for block ciphers.
 //!
 //! Mode functionality is accessed using traits from re-exported
-//! [`stream-cipher`](https://docs.rs/stream-cipher) crate.
+//! [`cipher`](https://docs.rs/cipher) crate.
 //!
-//! # Security Warning
+//! # ⚠️ Security Warning: [Hazmat!]
+//!
 //! This crate does not ensure ciphertexts are authentic! Thus ciphertext integrity
 //! is not verified, which can lead to serious vulnerabilities!
 //!
 //! # `Ctr128` Usage Example
+//!
 //! ```
-//! use ctr::stream_cipher::generic_array::GenericArray;
-//! use ctr::stream_cipher::{
-//!     NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek
-//! };
+//! use ctr::cipher::stream::{NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
 //!
 //! // `aes` crate provides AES block cipher implementation
 //! type Aes128Ctr = ctr::Ctr128<aes::Aes128>;
 //!
-//! # fn main() {
 //! let mut data = [1, 2, 3, 4, 5, 6, 7];
 //!
-//! let key = GenericArray::from_slice(b"very secret key.");
-//! let nonce = GenericArray::from_slice(b"and secret nonce");
+//! let key = b"very secret key.";
+//! let nonce = b"and secret nonce";
+//!
 //! // create cipher instance
-//! let mut cipher = Aes128Ctr::new(&key, &nonce);
+//! let mut cipher = Aes128Ctr::new(key.into(), nonce.into());
+//!
 //! // apply keystream (encrypt)
 //! cipher.apply_keystream(&mut data);
 //! assert_eq!(data, [6, 245, 126, 124, 180, 146, 37]);
@@ -32,8 +32,9 @@
 //! cipher.seek(0);
 //! cipher.apply_keystream(&mut data);
 //! assert_eq!(data, [1, 2, 3, 4, 5, 6, 7]);
-//! # }
 //! ```
+//!
+//! [Hazmat!]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 
 #![no_std]
 #![doc(
@@ -49,4 +50,4 @@ pub use crate::{
     ctr128::Ctr128,
     ctr32::{Ctr32BE, Ctr32LE},
 };
-pub use stream_cipher;
+pub use cipher;

--- a/ctr/tests/ctr128/mod.rs
+++ b/ctr/tests/ctr128/mod.rs
@@ -1,7 +1,7 @@
 type Aes128Ctr = ctr::Ctr128<aes::Aes128>;
 type Aes256Ctr = ctr::Ctr128<aes::Aes256>;
 
-stream_cipher::new_sync_test!(aes128_ctr_core, Aes128Ctr, "aes128-ctr");
-stream_cipher::new_sync_test!(aes256_ctr_core, Aes256Ctr, "aes256-ctr");
-stream_cipher::new_seek_test!(aes128_ctr_seek, Aes128Ctr);
-stream_cipher::new_seek_test!(aes256_ctr_seek, Aes256Ctr);
+cipher::new_sync_test!(aes128_ctr_core, Aes128Ctr, "aes128-ctr");
+cipher::new_sync_test!(aes256_ctr_core, Aes256Ctr, "aes256-ctr");
+cipher::new_seek_test!(aes128_ctr_seek, Aes128Ctr);
+cipher::new_seek_test!(aes256_ctr_seek, Aes256Ctr);

--- a/ctr/tests/ctr32/big_endian.rs
+++ b/ctr/tests/ctr32/big_endian.rs
@@ -1,7 +1,7 @@
 //! Counter Mode with a 32-bit big endian counter
 
+use cipher::stream::{NewStreamCipher, SyncStreamCipher};
 use hex_literal::hex;
-use stream_cipher::{NewStreamCipher, SyncStreamCipher};
 
 type Aes128Ctr = ctr::Ctr32BE<aes::Aes128>;
 

--- a/ctr/tests/ctr32/little_endian.rs
+++ b/ctr/tests/ctr32/little_endian.rs
@@ -1,7 +1,7 @@
 //! Counter Mode with a 32-bit little endian counter
 
+use cipher::stream::{NewStreamCipher, SyncStreamCipher};
 use hex_literal::hex;
-use stream_cipher::{NewStreamCipher, SyncStreamCipher};
 
 type Aes128Ctr = ctr::Ctr32LE<aes::Aes128>;
 

--- a/hc-256/Cargo.toml
+++ b/hc-256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hc-256"
-version = "0.2.0"
+version = "0.3.0-pre"
 authors = ["Eric McCorkle <eric@metricspace.net>"]
 license = "MIT OR Apache-2.0"
 description = "HC-256 Stream Cipher"
@@ -11,5 +11,5 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = "0.7"
+cipher = "0.2"
 zeroize = { version = "1", optional = true }

--- a/hc-256/src/lib.rs
+++ b/hc-256/src/lib.rs
@@ -8,11 +8,11 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
-pub use stream_cipher;
+pub use cipher;
 
-use stream_cipher::consts::U32;
-use stream_cipher::generic_array::GenericArray;
-use stream_cipher::{NewStreamCipher, StreamCipher};
+use cipher::stream::consts::U32;
+use cipher::stream::generic_array::GenericArray;
+use cipher::stream::{NewStreamCipher, StreamCipher};
 
 #[cfg(cargo_feature = "zeroize")]
 use std::ops::Drop;

--- a/hc-256/tests/lib.rs
+++ b/hc-256/tests/lib.rs
@@ -1,5 +1,5 @@
+use cipher::stream::{generic_array::GenericArray, NewStreamCipher, StreamCipher};
 use hc_256::Hc256;
-use stream_cipher::{generic_array::GenericArray, NewStreamCipher, StreamCipher};
 
 #[cfg(test)]
 const KEY_BYTES: usize = 256 / 8;

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ofb"
-version = "0.3.0"
+version = "0.4.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic Output Feedback (OFB) mode implementation."
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = { version = "0.7", features = ["block-cipher"] }
+cipher = "0.2"
 
 [dev-dependencies]
-aes = "0.5"
-stream-cipher = { version = "0.7", features = ["dev"] }
+aes = "0.6"
+cipher = { version = "0.2", features = ["dev"] }
 hex-literal = "0.2"

--- a/ofb/benches/cfb-mode.rs
+++ b/ofb/benches/cfb-mode.rs
@@ -1,3 +1,3 @@
 #![feature(test)]
 
-stream_cipher::bench_sync!(ofb::Ofb<aes::Aes128>);
+cipher::bench_sync!(ofb::Ofb<aes::Aes128>);

--- a/ofb/src/lib.rs
+++ b/ofb/src/lib.rs
@@ -11,7 +11,7 @@
 //! use aes::Aes128;
 //! use hex_literal::hex;
 //! use ofb::Ofb;
-//! use ofb::stream_cipher::{NewStreamCipher, SyncStreamCipher};
+//! use ofb::cipher::{NewStreamCipher, SyncStreamCipher};
 //!
 //! type AesOfb = Ofb<Aes128>;
 //!
@@ -53,14 +53,13 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
-pub use stream_cipher;
+pub use cipher;
 
-use stream_cipher::block_cipher::{BlockCipher, NewBlockCipher};
-use stream_cipher::generic_array::typenum::Unsigned;
-use stream_cipher::generic_array::GenericArray;
-use stream_cipher::{FromBlockCipher, LoopError, SyncStreamCipher};
-
-type Block<C> = GenericArray<u8, <C as BlockCipher>::BlockSize>;
+use cipher::{
+    block::{Block, BlockCipher, NewBlockCipher},
+    generic_array::typenum::Unsigned,
+    stream::{FromBlockCipher, LoopError, Nonce, SyncStreamCipher},
+};
 
 /// OFB self-synchronizing stream cipher instance.
 pub struct Ofb<C: BlockCipher> {
@@ -76,7 +75,7 @@ where
     type BlockCipher = C;
     type NonceSize = C::BlockSize;
 
-    fn from_block_cipher(cipher: C, iv: &GenericArray<u8, Self::NonceSize>) -> Self {
+    fn from_block_cipher(cipher: C, iv: &Nonce<Self>) -> Self {
         let mut block = iv.clone();
         cipher.encrypt_block(&mut block);
         Self {

--- a/ofb/tests/lib.rs
+++ b/ofb/tests/lib.rs
@@ -1,1 +1,1 @@
-stream_cipher::new_sync_test!(ofb_aes128, ofb::Ofb<aes::Aes128>, "aes128");
+cipher::new_sync_test!(ofb_aes128, ofb::Ofb<aes::Aes128>, "aes128");

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa20"
-version = "0.6.0"
+version = "0.7.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Salsa20 Stream Cipher"
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-stream-cipher = "0.7"
+cipher = "0.2"
 zeroize = { version = "1", optional = true }
 
 [dev-dependencies]
-stream-cipher = { version = "0.7", features = ["dev"] }
+cipher = { version = "0.2", features = ["dev"] }
 
 [features]
 default = ["xsalsa20"]

--- a/salsa20/benches/salsa20.rs
+++ b/salsa20/benches/salsa20.rs
@@ -1,3 +1,3 @@
 #![feature(test)]
 
-stream_cipher::bench_sync!(salsa20::Salsa20);
+cipher::bench_sync!(salsa20::Salsa20);

--- a/salsa20/src/xsalsa.rs
+++ b/salsa20/src/xsalsa.rs
@@ -1,16 +1,18 @@
 //! XSalsa20 is an extended nonce variant of Salsa20
 
 use crate::{block::quarter_round, Key, Salsa20, CONSTANTS, IV_SIZE};
-use core::convert::TryInto;
-use stream_cipher::{
+use cipher::{
     consts::{U16, U24, U32},
     generic_array::GenericArray,
-    LoopError, NewStreamCipher, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
+    stream::{
+        LoopError, NewStreamCipher, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
+    },
 };
+use core::convert::TryInto;
 
 /// EXtended Salsa20 nonce (192-bit/24-byte)
 #[cfg_attr(docsrs, doc(cfg(feature = "xsalsa20")))]
-pub type XNonce = stream_cipher::Nonce<XSalsa20>;
+pub type XNonce = cipher::stream::Nonce<XSalsa20>;
 
 /// XSalsa20 is a Salsa20 variant with an extended 192-bit (24-byte) nonce.
 ///

--- a/salsa20/tests/lib.rs
+++ b/salsa20/tests/lib.rs
@@ -1,14 +1,14 @@
 //! Salsa20 tests
 
+use cipher::stream::generic_array::GenericArray;
+use cipher::stream::{NewStreamCipher, StreamCipher, SyncStreamCipherSeek};
 use salsa20::Salsa20;
 #[cfg(feature = "xsalsa20")]
 use salsa20::XSalsa20;
-use stream_cipher::generic_array::GenericArray;
-use stream_cipher::{new_seek_test, NewStreamCipher, StreamCipher, SyncStreamCipherSeek};
 
-new_seek_test!(salsa20_seek, Salsa20);
+cipher::new_seek_test!(salsa20_seek, Salsa20);
 #[cfg(feature = "xsalsa20")]
-new_seek_test!(xsalsa20_seek, XSalsa20);
+cipher::new_seek_test!(xsalsa20_seek, XSalsa20);
 
 #[cfg(test)]
 const KEY_BYTES: usize = 32;


### PR DESCRIPTION
This PR replaces all previous usages of the `block-cipher` and `stream-cipher` crates with the new unified `cipher` crate.

See also: https://github.com/RustCrypto/traits/pull/337