### PR TITLE
salsa20: internal refactoring

### DIFF
--- a/salsa20/src/block.rs
+++ b/salsa20/src/block.rs
@@ -1,6 +1,6 @@
 //! The Salsa20 block function.
 
-use crate::{rounds::Rounds, BLOCK_SIZE, CONSTANTS, IV_SIZE, KEY_SIZE, STATE_WORDS};
+use crate::{rounds::Rounds, Key, Nonce, BLOCK_SIZE, CONSTANTS, STATE_WORDS};
 use core::{convert::TryInto, marker::PhantomData, mem};
 
 /// The Salsa20 block function
@@ -18,7 +18,7 @@ pub(crate) struct Block<R: Rounds> {
 
 impl<R: Rounds> Block<R> {
     /// Initialize block function with the given key and IV
-    pub(crate) fn new(key: &[u8; KEY_SIZE], iv: [u8; IV_SIZE]) -> Self {
+    pub(crate) fn new(key: &Key, iv: &Nonce) -> Self {
         #[allow(unsafe_code)]
         let mut state: [u32; STATE_WORDS] = unsafe { mem::zeroed() };
         state[0] = CONSTANTS[0];

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -64,24 +64,13 @@ mod salsa;
 #[cfg(feature = "xsalsa20")]
 mod xsalsa;
 
+pub use crate::salsa::{Key, Nonce, Salsa, Salsa12, Salsa20, Salsa8};
+
 #[cfg(feature = "xsalsa20")]
-pub use self::xsalsa::{XNonce, XSalsa20};
+pub use crate::xsalsa::{XNonce, XSalsa20};
 
 #[cfg(feature = "hsalsa20")]
-pub use self::xsalsa::hsalsa20;
-
-use crate::{
-    block::Block,
-    rounds::{Rounds, R12, R20, R8},
-    salsa::SalsaCore,
-};
-use cipher::{
-    consts::{U32, U8},
-    stream::{
-        LoopError, NewStreamCipher, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
-    },
-};
-use core::convert::TryInto;
+pub use crate::xsalsa::hsalsa20;
 
 /// Size of a Salsa20 block in bytes
 pub const BLOCK_SIZE: usize = 64;
@@ -89,71 +78,8 @@ pub const BLOCK_SIZE: usize = 64;
 /// Size of a Salsa20 key in bytes
 pub const KEY_SIZE: usize = 32;
 
-/// Number of bytes in the Salsa20 IV
-const IV_SIZE: usize = 8;
-
 /// Number of 32-bit words in the Salsa20 state
 const STATE_WORDS: usize = 16;
 
 /// State initialization constant ("expand 32-byte k")
 const CONSTANTS: [u32; 4] = [0x6170_7865, 0x3320_646e, 0x7962_2d32, 0x6b20_6574];
-
-/// Salsa20/8 stream cipher
-/// (reduced-round variant of Salsa20 with 8 rounds, *not recommended*)
-pub type Salsa8 = Salsa<R8>;
-
-/// Salsa20/12 stream cipher
-/// (reduced-round variant of Salsa20 with 12 rounds, *not recommended*)
-pub type Salsa12 = Salsa<R12>;
-
-/// Salsa20/20 stream cipher
-/// (20 rounds; **recommended**)
-pub type Salsa20 = Salsa<R20>;
-
-/// Key type.
-///
-/// Implemented as an alias for [`GenericArray`].
-///
-/// (NOTE: all three round variants use the same key size)
-pub type Key = cipher::stream::Key<Salsa20>;
-
-/// Nonce type.
-///
-/// Implemented as an alias for [`GenericArray`].
-pub type Nonce = cipher::stream::Nonce<Salsa20>;
-
-/// The Salsa20 family of stream ciphers
-/// (implemented generically over a number of rounds).
-///
-/// We recommend you use the [`Salsa20`] (a.k.a. Salsa20/20) variant.
-#[derive(Debug)]
-pub struct Salsa<R: Rounds>(SalsaCore<R>);
-
-impl<R: Rounds> NewStreamCipher for Salsa<R> {
-    /// Key size in bytes
-    type KeySize = U32;
-
-    /// Nonce size in bytes
-    type NonceSize = U8;
-
-    fn new(key: &Key, nonce: &Nonce) -> Self {
-        let block = Block::new(key.as_slice().try_into().unwrap(), (*nonce).into());
-        Salsa(SalsaCore::new(block))
-    }
-}
-
-impl<R: Rounds> SyncStreamCipherSeek for Salsa<R> {
-    fn try_current_pos<T: SeekNum>(&self) -> Result<T, OverflowError> {
-        self.0.try_current_pos()
-    }
-
-    fn try_seek<T: SeekNum>(&mut self, pos: T) -> Result<(), LoopError> {
-        self.0.try_seek(pos)
-    }
-}
-
-impl<R: Rounds> SyncStreamCipher for Salsa<R> {
-    fn try_apply_keystream(&mut self, data: &mut [u8]) -> Result<(), LoopError> {
-        self.0.try_apply_keystream(data)
-    }
-}

--- a/salsa20/src/xsalsa.rs
+++ b/salsa20/src/xsalsa.rs
@@ -1,6 +1,6 @@
 //! XSalsa20 is an extended nonce variant of Salsa20
 
-use crate::{block::quarter_round, Key, Salsa20, CONSTANTS, IV_SIZE};
+use crate::{block::quarter_round, Key, Nonce, Salsa20, CONSTANTS};
 use cipher::{
     consts::{U16, U24, U32},
     generic_array::GenericArray,
@@ -35,10 +35,10 @@ impl NewStreamCipher for XSalsa20 {
     #[allow(unused_mut, clippy::let_and_return)]
     fn new(key: &Key, nonce: &XNonce) -> Self {
         let mut subkey = hsalsa20(key, nonce[..16].as_ref().into());
-        let mut padded_nonce = [0u8; IV_SIZE];
+        let mut padded_nonce = Nonce::default();
         padded_nonce.copy_from_slice(&nonce[16..]);
 
-        let mut result = XSalsa20(Salsa20::new(&subkey, &padded_nonce.into()));
+        let mut result = XSalsa20(Salsa20::new(&subkey, &padded_nonce));
 
         #[cfg(feature = "zeroize")]
         {


### PR DESCRIPTION
Unifies the `Salsa`/`SalsaCore` types, as one was previously just a thin wrapper around the other.

This matches the structure of the `chacha20` crate.