### PR TITLE
Release new versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aes-ctr"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "aes-soft",
  "aesni",
@@ -56,7 +56,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cfb-mode"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "aes",
  "cipher",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "cfb8"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "aes",
  "cipher",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "aes",
  "cipher",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "hc-256"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "cipher",
  "zeroize",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "ofb"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "aes",
  "cipher",
@@ -167,7 +167,7 @@ checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "salsa20"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "cipher",
  "zeroize",

--- a/aes-ctr/CHANGELOG.md
+++ b/aes-ctr/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#177])
+
+[#177]: https://github.com/RustCrypto/stream-ciphers/pull/177
+
 ## 0.5.0 (2020-08-25)
 ### Changed
 - Bump `stream-cipher` dependency to v0.7, implement the `FromBlockCipher` trait ([#161], [#164])

--- a/aes-ctr/Cargo.toml
+++ b/aes-ctr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-ctr"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = "AES-CTR stream ciphers"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ edition = "2018"
 cipher = "0.2"
 
 [target.'cfg(not(all(target_feature = "aes", target_feature = "sse2", target_feature = "ssse3", any(target_arch = "x86_64", target_arch = "x86"))))'.dependencies]
-ctr = { version = "0.6.0-pre", path = "../ctr" }
+ctr = { version = "0.6", path = "../ctr" }
 aes-soft = "0.6"
 
 [target.'cfg(all(target_feature = "aes", target_feature = "sse2", target_feature = "ssse3", any(target_arch = "x86_64", target_arch = "x86")))'.dependencies]

--- a/cfb-mode/CHANGELOG.md
+++ b/cfb-mode/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#177])
+
+[#177]: https://github.com/RustCrypto/stream-ciphers/pull/177
+
 ## 0.5.0 (2020-08-25)
 ### Changed
 - Bump `stream-cipher` dependency to v0.7, implement the `FromBlockCipher` trait ([#161], [#164])

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfb-mode"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = "Generic Cipher Feedback (CFB) mode implementation."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cfb8/CHANGELOG.md
+++ b/cfb8/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#177])
+
+[#177]: https://github.com/RustCrypto/stream-ciphers/pull/177
+
 ## 0.5.0 (2020-08-25)
 ### Changed
 - Bump `stream-cipher` dependency to v0.7, implement the `FromBlockCipher` trait ([#161], [#164])

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfb8"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = "Generic 8-bit Cipher Feedback (CFB8) mode implementation."
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/chacha20/CHANGELOG.md
+++ b/chacha20/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-10-16)
+### Changed
+- Rename `Cipher` to `ChaCha` ([#177])
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#177])
+
+[#177]: https://github.com/RustCrypto/stream-ciphers/pull/177
+
 ## 0.5.0 (2020-08-25)
 ### Changed
 - Bump `stream-cipher` dependency to v0.7 ([#161], [#164])

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.6.0-pre"
+version = "0.6.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/ctr/CHANGELOG.md
+++ b/ctr/CHANGELOG.md
@@ -5,10 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.6.0-pre (2020-10-14)
+## 0.6.0 (2020-10-16)
 ### Added
 - `Ctr32BE` and `Ctr32LE` ([#170])
 
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#177])
+
+[#177]: https://github.com/RustCrypto/stream-ciphers/pull/177
 [#170]: https://github.com/RustCrypto/stream-ciphers/pull/170
 
 ## 0.5.0 (2020-08-26)

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctr"
-version = "0.6.0-pre"
+version = "0.6.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "CTR block mode of operation"

--- a/hc-256/CHANGELOG.md
+++ b/hc-256/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#177])
+
+[#177]: https://github.com/RustCrypto/stream-ciphers/pull/177
+
 ## 0.2.0 (2020-08-25)
 ### Changed
 - Bump `stream-cipher` dependency to v0.7, rename `HC256` to `Hc256` ([#161], [#164])

--- a/hc-256/Cargo.toml
+++ b/hc-256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hc-256"
-version = "0.3.0-pre"
+version = "0.3.0"
 authors = ["Eric McCorkle <eric@metricspace.net>"]
 license = "MIT OR Apache-2.0"
 description = "HC-256 Stream Cipher"

--- a/ofb/CHANGELOG.md
+++ b/ofb/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#177])
+
+[#177]: https://github.com/RustCrypto/stream-ciphers/pull/177
+
 ## 0.3.0 (2020-08-25)
 ### Changed
 - Bump `stream-cipher` dependency to v0.7, implement the `FromBlockCipher` trait ([#161], [#164])

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ofb"
-version = "0.4.0-pre"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Generic Output Feedback (OFB) mode implementation."

--- a/salsa20/CHANGELOG.md
+++ b/salsa20/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-10-16)
+### Changed
+- Replace `block-cipher`/`stream-cipher` with `cipher` crate ([#177])
+- Renamed `Cipher` to `Salsa` ([#177])
+
+[#177]: https://github.com/RustCrypto/stream-ciphers/pull/177
+
 ## 0.6.0 (2020-08-25)
 ### Changed
 - Bump `stream-cipher` dependency to v0.7 ([#161], [#164])

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa20"
-version = "0.7.0-pre"
+version = "0.7.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Salsa20 Stream Cipher"


### PR DESCRIPTION
Releases new versions of all crates in this repository which incorporate the migration to the new `cipher` crate (#177).