### PR TITLE
salsa20: add `expose-core` feature

### DIFF
--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -19,9 +19,10 @@ cipher = { version = "0.2", features = ["dev"] }
 
 [features]
 default = ["xsalsa20"]
+expose-core = []
 hsalsa20 = ["xsalsa20"]
 xsalsa20 = []
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["hsalsa20", "xsalsa20"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -66,11 +66,17 @@ mod xsalsa;
 
 pub use crate::salsa::{Key, Nonce, Salsa, Salsa12, Salsa20, Salsa8};
 
-#[cfg(feature = "xsalsa20")]
-pub use crate::xsalsa::{XNonce, XSalsa20};
+#[cfg(feature = "expose-core")]
+pub use crate::{
+    block::Block,
+    rounds::{R12, R20, R8},
+};
 
 #[cfg(feature = "hsalsa20")]
 pub use crate::xsalsa::hsalsa20;
+
+#[cfg(feature = "xsalsa20")]
+pub use crate::xsalsa::{XNonce, XSalsa20};
 
 /// Size of a Salsa20 block in bytes
 pub const BLOCK_SIZE: usize = 64;

--- a/salsa20/src/salsa.rs
+++ b/salsa20/src/salsa.rs
@@ -116,7 +116,8 @@ impl<R: Rounds> SyncStreamCipher for Salsa<R> {
         self.buffer_pos = rem.len() as u8;
         self.counter = counter;
         if !rem.is_empty() {
-            self.block.generate(counter, &mut self.buffer);
+            self.block.counter_setup(counter);
+            self.block.generate(&mut self.buffer);
             xor(rem, &self.buffer[..rem.len()]);
         }
 
@@ -134,7 +135,8 @@ impl<R: Rounds> SyncStreamCipherSeek for Salsa<R> {
         self.counter = res.0;
         self.buffer_pos = res.1;
         if self.buffer_pos != 0 {
-            self.block.generate(self.counter, &mut self.buffer);
+            self.block.counter_setup(self.counter);
+            self.block.generate(&mut self.buffer);
         }
         Ok(())
     }


### PR DESCRIPTION
Cargo feature to expose `salsa20::Block` as part of the public API.

This can be used by the `scrypt` crate to implement the Salsa20/8 core function, rather than vendoring an implementation. This allows us to work on optimizations in a single place (i.e. this crate).