### PR TITLE
chacha20/Cargo.toml: update description

### DIFF
--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
 The ChaCha20 stream cipher (RFC 8439) implemented in pure Rust using traits
-from the RustCrypto stream-cipher crate, with optional architecture-specific
+from the RustCrypto `cipher` crate, with optional architecture-specific
 hardware acceleration (AVX2, SSE2). Additionally provides the ChaCha8, ChaCha12,
 and XChaCha20 stream ciphers, and also optional rand_core-compatible RNGs based
 on those ciphers.


### PR DESCRIPTION
It presently refers to the now defunct `stream-cipher` crate