### PR TITLE
Bump `cipher` crate to v0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.2.1"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f7954ae5588102b35257639b1c36a2e7425cc6540fcdb4de19dcb91055d659"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
 dependencies = [
  "blobby",
  "generic-array",

--- a/aes-ctr/benches/aes128_ctr.rs
+++ b/aes-ctr/benches/aes128_ctr.rs
@@ -1,3 +1,3 @@
 #![feature(test)]
 
-cipher::bench_sync!(aes_ctr::Aes128Ctr);
+cipher::stream_cipher_sync_bench!(aes_ctr::Aes128Ctr);

--- a/aes-ctr/benches/aes192_ctr.rs
+++ b/aes-ctr/benches/aes192_ctr.rs
@@ -1,3 +1,3 @@
 #![feature(test)]
 
-cipher::bench_sync!(aes_ctr::Aes192Ctr);
+cipher::stream_cipher_sync_bench!(aes_ctr::Aes192Ctr);

--- a/aes-ctr/benches/aes256_ctr.rs
+++ b/aes-ctr/benches/aes256_ctr.rs
@@ -1,3 +1,3 @@
 #![feature(test)]
 
-cipher::bench_sync!(aes_ctr::Aes128Ctr);
+cipher::stream_cipher_sync_bench!(aes_ctr::Aes128Ctr);

--- a/aes-ctr/tests/lib.rs
+++ b/aes-ctr/tests/lib.rs
@@ -2,7 +2,7 @@
 
 use aes_ctr::{Aes128Ctr, Aes256Ctr};
 
-cipher::new_sync_test!(aes128_ctr_core, Aes128Ctr, "aes128-ctr");
-cipher::new_sync_test!(aes256_ctr_core, Aes256Ctr, "aes256-ctr");
-cipher::new_seek_test!(aes128_ctr_seek, Aes128Ctr);
-cipher::new_seek_test!(aes256_ctr_seek, Aes256Ctr);
+cipher::stream_cipher_sync_test!(aes128_ctr_core, Aes128Ctr, "aes128-ctr");
+cipher::stream_cipher_sync_test!(aes256_ctr_core, Aes256Ctr, "aes256-ctr");
+cipher::stream_cipher_seek_test!(aes128_ctr_seek, Aes128Ctr);
+cipher::stream_cipher_seek_test!(aes256_ctr_seek, Aes256Ctr);

--- a/cfb-mode/benches/cfb-mode.rs
+++ b/cfb-mode/benches/cfb-mode.rs
@@ -1,3 +1,3 @@
 #![feature(test)]
 
-cipher::bench_async!(cfb_mode::Cfb<aes::Aes128>);
+cipher::stream_cipher_async_bench!(cfb_mode::Cfb<aes::Aes128>);

--- a/cfb-mode/tests/lib.rs
+++ b/cfb-mode/tests/lib.rs
@@ -2,6 +2,6 @@ use cfb_mode::Cfb;
 
 // tests vectors are from:
 // https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf
-cipher::new_async_test!(cfb_aes128, "aes128", Cfb<aes::Aes128>);
-cipher::new_async_test!(cfb_aes192, "aes192", Cfb<aes::Aes192>);
-cipher::new_async_test!(cfb_aes256, "aes256", Cfb<aes::Aes256>);
+cipher::stream_cipher_async_test!(cfb_aes128, "aes128", Cfb<aes::Aes128>);
+cipher::stream_cipher_async_test!(cfb_aes192, "aes192", Cfb<aes::Aes192>);
+cipher::stream_cipher_async_test!(cfb_aes256, "aes256", Cfb<aes::Aes256>);

--- a/cfb8/benches/cfb8.rs
+++ b/cfb8/benches/cfb8.rs
@@ -1,3 +1,3 @@
 #![feature(test)]
 
-cipher::bench_async!(cfb8::Cfb8<aes::Aes128>);
+cipher::stream_cipher_async_bench!(cfb8::Cfb8<aes::Aes128>);

--- a/cfb8/tests/lib.rs
+++ b/cfb8/tests/lib.rs
@@ -2,6 +2,6 @@ use cfb8::Cfb8;
 
 // tests vectors are from:
 // https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf
-cipher::new_async_test!(cfb8_aes128, "aes128", Cfb8<aes::Aes128>);
-cipher::new_async_test!(cfb8_aes192, "aes192", Cfb8<aes::Aes192>);
-cipher::new_async_test!(cfb8_aes256, "aes256", Cfb8<aes::Aes256>);
+cipher::stream_cipher_async_test!(cfb8_aes128, "aes128", Cfb8<aes::Aes128>);
+cipher::stream_cipher_async_test!(cfb8_aes192, "aes192", Cfb8<aes::Aes192>);
+cipher::stream_cipher_async_test!(cfb8_aes256, "aes256", Cfb8<aes::Aes256>);

--- a/chacha20/benches/chacha12.rs
+++ b/chacha20/benches/chacha12.rs
@@ -1,4 +1,4 @@
 #![cfg(feature = "cipher")]
 #![feature(test)]
 
-cipher::bench_sync!(chacha20::ChaCha12);
+cipher::stream_cipher_sync_bench!(chacha20::ChaCha12);

--- a/chacha20/benches/chacha20.rs
+++ b/chacha20/benches/chacha20.rs
@@ -1,4 +1,4 @@
 #![cfg(feature = "cipher")]
 #![feature(test)]
 
-cipher::bench_sync!(chacha20::ChaCha20);
+cipher::stream_cipher_sync_bench!(chacha20::ChaCha20);

--- a/chacha20/benches/chacha8.rs
+++ b/chacha20/benches/chacha8.rs
@@ -1,4 +1,4 @@
 #![cfg(feature = "cipher")]
 #![feature(test)]
 
-cipher::bench_sync!(chacha20::ChaCha8);
+cipher::stream_cipher_sync_bench!(chacha20::ChaCha8);

--- a/chacha20/tests/lib.rs
+++ b/chacha20/tests/lib.rs
@@ -3,8 +3,8 @@
 use chacha20::ChaCha20;
 
 // IETF version of ChaCha20 (96-bit nonce)
-cipher::new_sync_test!(chacha20_core, ChaCha20, "chacha20");
-cipher::new_seek_test!(chacha20_seek, ChaCha20);
+cipher::stream_cipher_sync_test!(chacha20_core, ChaCha20, "chacha20");
+cipher::stream_cipher_seek_test!(chacha20_seek, ChaCha20);
 
 #[cfg(feature = "xchacha20")]
 #[rustfmt::skip]
@@ -13,7 +13,7 @@ mod xchacha20 {
     use cipher::stream::{NewStreamCipher, StreamCipher};
     use hex_literal::hex;
 
-    cipher::new_seek_test!(xchacha20_seek, XChaCha20);
+    cipher::stream_cipher_seek_test!(xchacha20_seek, XChaCha20);
 
     //
     // XChaCha20 test vectors from:
@@ -102,8 +102,8 @@ mod legacy {
     use cipher::stream::{NewStreamCipher, StreamCipher, SyncStreamCipherSeek};
     use hex_literal::hex;
 
-    cipher::new_sync_test!(chacha20_legacy_core, ChaCha20Legacy, "chacha20-legacy");
-    cipher::new_seek_test!(chacha20_legacy_seek, ChaCha20Legacy);
+    cipher::stream_cipher_sync_test!(chacha20_legacy_core, ChaCha20Legacy, "chacha20-legacy");
+    cipher::stream_cipher_seek_test!(chacha20_legacy_seek, ChaCha20Legacy);
 
     const KEY_LONG: [u8; 32] = hex!("
         0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20

--- a/ctr/benches/aes128.rs
+++ b/ctr/benches/aes128.rs
@@ -1,3 +1,3 @@
 #![feature(test)]
 
-cipher::bench_sync!(ctr::Ctr128<aes::Aes128>);
+cipher::stream_cipher_sync_bench!(ctr::Ctr128<aes::Aes128>);

--- a/ctr/tests/ctr128/mod.rs
+++ b/ctr/tests/ctr128/mod.rs
@@ -1,7 +1,7 @@
 type Aes128Ctr = ctr::Ctr128<aes::Aes128>;
 type Aes256Ctr = ctr::Ctr128<aes::Aes256>;
 
-cipher::new_sync_test!(aes128_ctr_core, Aes128Ctr, "aes128-ctr");
-cipher::new_sync_test!(aes256_ctr_core, Aes256Ctr, "aes256-ctr");
-cipher::new_seek_test!(aes128_ctr_seek, Aes128Ctr);
-cipher::new_seek_test!(aes256_ctr_seek, Aes256Ctr);
+cipher::stream_cipher_sync_test!(aes128_ctr_core, Aes128Ctr, "aes128-ctr");
+cipher::stream_cipher_sync_test!(aes256_ctr_core, Aes256Ctr, "aes256-ctr");
+cipher::stream_cipher_seek_test!(aes128_ctr_seek, Aes128Ctr);
+cipher::stream_cipher_seek_test!(aes256_ctr_seek, Aes256Ctr);

--- a/ofb/benches/cfb-mode.rs
+++ b/ofb/benches/cfb-mode.rs
@@ -1,3 +1,3 @@
 #![feature(test)]
 
-cipher::bench_sync!(ofb::Ofb<aes::Aes128>);
+cipher::stream_cipher_sync_bench!(ofb::Ofb<aes::Aes128>);

--- a/ofb/tests/lib.rs
+++ b/ofb/tests/lib.rs
@@ -1,1 +1,1 @@
-cipher::new_sync_test!(ofb_aes128, ofb::Ofb<aes::Aes128>, "aes128");
+cipher::stream_cipher_sync_test!(ofb_aes128, ofb::Ofb<aes::Aes128>, "aes128");

--- a/rabbit/benches/rabbit.rs
+++ b/rabbit/benches/rabbit.rs
@@ -1,3 +1,3 @@
 #![feature(test)]
 
-cipher::bench_sync!(rabbit::Rabbit);
+cipher::stream_cipher_sync_bench!(rabbit::Rabbit);

--- a/salsa20/benches/salsa20.rs
+++ b/salsa20/benches/salsa20.rs
@@ -1,3 +1,3 @@
 #![feature(test)]
 
-cipher::bench_sync!(salsa20::Salsa20);
+cipher::stream_cipher_sync_bench!(salsa20::Salsa20);

--- a/salsa20/tests/lib.rs
+++ b/salsa20/tests/lib.rs
@@ -6,9 +6,9 @@ use salsa20::Salsa20;
 #[cfg(feature = "xsalsa20")]
 use salsa20::XSalsa20;
 
-cipher::new_seek_test!(salsa20_seek, Salsa20);
+cipher::stream_cipher_seek_test!(salsa20_seek, Salsa20);
 #[cfg(feature = "xsalsa20")]
-cipher::new_seek_test!(xsalsa20_seek, XSalsa20);
+cipher::stream_cipher_seek_test!(xsalsa20_seek, XSalsa20);
 
 #[cfg(test)]
 const KEY_BYTES: usize = 32;


### PR DESCRIPTION
This PR also addresses the deprecation warnings which were introduced