### PR TITLE
salsa20: do not use zeroize default features to prevent alloc inclusion

### DIFF
--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 cipher = "0.2"
-zeroize = { version = "1", optional = true }
+zeroize = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 cipher = { version = "0.2", features = ["dev"] }


### PR DESCRIPTION
Should be OK as this crate does not use any zeroize alloc functionality.

Stumbled on this when developing embedded firmware, and got the following message during build of the binary:
```
error: no global memory allocator found but one is required; link to std or add `#[global_allocator]` to a static item that implements the GlobalAlloc trait.
```