### PR TITLE
salsa20 v0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "salsa20"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "cipher",
  "zeroize",

--- a/salsa20/CHANGELOG.md
+++ b/salsa20/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.2 (2020-11-11)
+### Fixed
+- `no_std` builds with `zeroize` feature enabled ([#189])
+
+[#189]: https://github.com/RustCrypto/stream-ciphers/pull/189
+
 ## 0.7.1 (2020-10-18)
 ### Added
 - `expose-core` feature ([#180])

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa20"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Salsa20 Stream Cipher"


### PR DESCRIPTION
### Fixed
- `no_std` builds with `zeroize` feature enabled ([#189])

[#189]: https://github.com/RustCrypto/stream-ciphers/pull/189