### PR TITLE
chacha20: fix `rng` feature on big endian platforms

### DIFF
--- a/.github/workflows/chacha20.yml
+++ b/.github/workflows/chacha20.yml
@@ -164,11 +164,10 @@ jobs:
             rust: stable
 
           # PPC32
-          # TODO(tarcieri): debug (big endian-related?) test failures
-          #- target: powerpc-unknown-linux-gnu
-          #  rust: 1.41.0 # MSRV
-          #- target: powerpc-unknown-linux-gnu
-          #  rust: stable
+          - target: powerpc-unknown-linux-gnu
+            rust: 1.41.0 # MSRV
+          - target: powerpc-unknown-linux-gnu
+            rust: stable
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
It wasn't necessarily "broken" in that it doesn't really matter what endianness random data comes in, but this at least makes the RNG output consistent on big and little endian platforms.