### PR TITLE
chacha20+salsa20: `Core` types

### DIFF
--- a/.github/workflows/chacha20.yml
+++ b/.github/workflows/chacha20.yml
@@ -53,10 +53,10 @@ jobs:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
             rust: 1.41.0 # MSRV
-            deps: sudo apt install gcc-multilib
+            deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
-            deps: sudo apt install gcc-multilib
+            deps: sudo apt update && sudo apt install gcc-multilib
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
@@ -90,10 +90,10 @@ jobs:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
             rust: 1.41.0 # MSRV
-            deps: sudo apt install gcc-multilib
+            deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
-            deps: sudo apt install gcc-multilib
+            deps: sudo apt update && sudo apt install gcc-multilib
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
@@ -126,10 +126,10 @@ jobs:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
             rust: 1.41.0 # MSRV
-            deps: sudo apt install gcc-multilib
+            deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
-            deps: sudo apt install gcc-multilib
+            deps: sudo apt update && sudo apt install gcc-multilib
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -31,6 +31,7 @@ hex-literal = "0.2"
 
 [features]
 default = ["xchacha20"]
+expose-core = []
 force-soft = []
 legacy = ["cipher"]
 rng = ["rand_core"]
@@ -38,5 +39,5 @@ std = ["cipher/std"]
 xchacha20 = ["cipher"]
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["legacy", "rng", "std", "xchacha20"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/chacha20/src/backend.rs
+++ b/chacha20/src/backend.rs
@@ -1,5 +1,6 @@
-//! The ChaCha20 block function. Defined in RFC 8439 Section 2.3.
+//! Backends providing the ChaCha20 core function.
 //!
+//! Defined in RFC 8439 Section 2.3:
 //! <https://tools.ietf.org/html/rfc8439#section-2.3>
 
 use cfg_if::cfg_if;
@@ -14,12 +15,14 @@ cfg_if! {
         pub(crate) mod avx2;
         pub(crate) mod sse2;
 
-        pub(crate) use self::autodetect::{State, BUFFER_SIZE};
+        pub(crate) use self::autodetect::BUFFER_SIZE;
+        pub use self::autodetect::Core;
 
         #[cfg(feature = "xchacha20")]
         pub(crate) mod soft;
     } else {
         pub(crate) mod soft;
-        pub(crate) use self::soft::{State, BUFFER_SIZE};
+        pub(crate) use self::soft::BUFFER_SIZE;
+        pub use self::soft::Core;
     }
 }

--- a/chacha20/src/backend/soft.rs
+++ b/chacha20/src/backend/soft.rs
@@ -1,4 +1,4 @@
-//! The ChaCha20 block function. Defined in RFC 8439 Section 2.3.
+//! The ChaCha20 core function. Defined in RFC 8439 Section 2.3.
 //!
 //! <https://tools.ietf.org/html/rfc8439#section-2.3>
 //!
@@ -15,12 +15,12 @@ pub(crate) const BUFFER_SIZE: usize = BLOCK_SIZE;
 /// Number of 32-bit words in the ChaCha20 state
 const STATE_WORDS: usize = 16;
 
-/// The ChaCha20 block function (portable software implementation)
+/// The ChaCha20 core function.
 // TODO(tarcieri): zeroize?
 #[derive(Clone)]
 #[allow(dead_code)]
-pub(crate) struct State<R: Rounds> {
-    /// Internal state of the block function
+pub struct Core<R: Rounds> {
+    /// Internal state of the core function
     state: [u32; STATE_WORDS],
 
     /// Number of rounds to perform
@@ -28,9 +28,9 @@ pub(crate) struct State<R: Rounds> {
 }
 
 #[allow(dead_code)]
-impl<R: Rounds> State<R> {
-    /// Initialize block function with the given key, IV, and number of rounds
-    pub(crate) fn new(key: &[u8; KEY_SIZE], iv: [u8; IV_SIZE]) -> Self {
+impl<R: Rounds> Core<R> {
+    /// Initialize core function with the given key, IV, and number of rounds
+    pub fn new(key: &[u8; KEY_SIZE], iv: [u8; IV_SIZE]) -> Self {
         let state = [
             CONSTANTS[0],
             CONSTANTS[1],
@@ -58,7 +58,7 @@ impl<R: Rounds> State<R> {
 
     /// Generate output, overwriting data already in the buffer
     #[inline]
-    pub(crate) fn generate(&mut self, counter: u64, output: &mut [u8]) {
+    pub fn generate(&mut self, counter: u64, output: &mut [u8]) {
         debug_assert_eq!(output.len(), BUFFER_SIZE);
         self.counter_setup(counter);
 
@@ -73,7 +73,7 @@ impl<R: Rounds> State<R> {
     /// Apply generated keystream to the output buffer
     #[inline]
     #[cfg(feature = "cipher")]
-    pub(crate) fn apply_keystream(&mut self, counter: u64, output: &mut [u8]) {
+    pub fn apply_keystream(&mut self, counter: u64, output: &mut [u8]) {
         debug_assert_eq!(output.len(), BUFFER_SIZE);
         self.counter_setup(counter);
 

--- a/chacha20/src/chacha.rs
+++ b/chacha20/src/chacha.rs
@@ -5,7 +5,7 @@
 // TODO(tarcieri): figure out how to unify this with the `ctr` crate (see #95)
 
 use crate::{
-    backend::{State, BUFFER_SIZE},
+    backend::{Core, BUFFER_SIZE},
     rounds::{Rounds, R12, R20, R8},
     BLOCK_SIZE, MAX_BLOCKS,
 };
@@ -60,10 +60,10 @@ const COUNTER_INCR: u64 = (BUFFER_SIZE as u64) / (BLOCK_SIZE as u64);
 ///
 /// Generally [`ChaCha20`] is preferred.
 pub struct ChaCha<R: Rounds> {
-    /// ChaCha20 block function initialized with a key and IV
-    block: State<R>,
+    /// ChaCha20 core function initialized with a key and IV
+    block: Core<R>,
 
-    /// Buffer containing previous block function output
+    /// Buffer containing previous output
     buffer: Buffer,
 
     /// Position within buffer, or `None` if the buffer is not in use
@@ -86,7 +86,7 @@ impl<R: Rounds> NewStreamCipher for ChaCha<R> {
     type NonceSize = U12;
 
     fn new(key: &Key, nonce: &Nonce) -> Self {
-        let block = State::new(
+        let block = Core::new(
             key.as_slice().try_into().unwrap(),
             nonce[4..12].try_into().unwrap(),
         );

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -91,6 +91,12 @@ pub use cipher;
 #[cfg(feature = "cipher")]
 pub use crate::chacha::{ChaCha, ChaCha12, ChaCha20, ChaCha8, Key, Nonce};
 
+#[cfg(feature = "expose-core")]
+pub use crate::{
+    backend::Core,
+    rounds::{R12, R20, R8},
+};
+
 #[cfg(feature = "legacy")]
 pub use crate::legacy::{ChaCha20Legacy, LegacyNonce};
 

--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -4,7 +4,7 @@ use rand_core::block::{BlockRng, BlockRngCore};
 use rand_core::{CryptoRng, Error, RngCore, SeedableRng};
 
 use crate::{
-    backend::{State, BUFFER_SIZE},
+    backend::{Core, BUFFER_SIZE},
     rounds::{R12, R20, R8},
     KEY_SIZE, MAX_BLOCKS,
 };
@@ -55,7 +55,7 @@ macro_rules! impl_chacha_rng {
         #[derive(Clone)]
         #[cfg_attr(docsrs, doc(cfg(feature = "rng")))]
         pub struct $core {
-            block: State<$rounds>,
+            block: Core<$rounds>,
             counter: u64,
         }
 
@@ -64,7 +64,7 @@ macro_rules! impl_chacha_rng {
 
             #[inline]
             fn from_seed(seed: Self::Seed) -> Self {
-                let block = State::new(&seed, Default::default());
+                let block = Core::new(&seed, Default::default());
                 Self { block, counter: 0 }
             }
         }

--- a/chacha20/src/rounds.rs
+++ b/chacha20/src/rounds.rs
@@ -1,5 +1,6 @@
 //! Numbers of rounds allowed to be used with the ChaCha stream cipher
 
+/// Marker type for a number of ChaCha rounds to perform.
 pub trait Rounds: Copy {
     const COUNT: usize;
 }

--- a/salsa20/src/core.rs
+++ b/salsa20/src/core.rs
@@ -1,23 +1,20 @@
-//! The Salsa20 block function.
+//! The Salsa20 core function.
 
 use crate::{rounds::Rounds, Key, Nonce, BLOCK_SIZE, CONSTANTS, STATE_WORDS};
 use core::{convert::TryInto, marker::PhantomData, mem};
 
-/// The Salsa20 block function
-///
-/// While Salsa20 is a stream cipher, not a block cipher, its core
-/// primitive is a function which acts on a 512-bit block
-// TODO(tarcieri): zeroize? need to make sure we're actually copying first
-pub struct Block<R: Rounds> {
-    /// Internal state of the block function
+/// The Salsa20 core function.
+// TODO(tarcieri): zeroize support
+pub struct Core<R: Rounds> {
+    /// Internal state of the core function
     state: [u32; STATE_WORDS],
 
     /// Number of rounds to perform
     rounds: PhantomData<R>,
 }
 
-impl<R: Rounds> Block<R> {
-    /// Initialize block function with the given key and IV
+impl<R: Rounds> Core<R> {
+    /// Initialize core function with the given key and IV
     pub fn new(key: &Key, iv: &Nonce) -> Self {
         #[allow(unsafe_code)]
         let mut state: [u32; STATE_WORDS] = unsafe { mem::zeroed() };
@@ -105,8 +102,8 @@ impl<R: Rounds> Block<R> {
     }
 }
 
-impl<R: Rounds> From<[u32; STATE_WORDS]> for Block<R> {
-    fn from(state: [u32; STATE_WORDS]) -> Block<R> {
+impl<R: Rounds> From<[u32; STATE_WORDS]> for Core<R> {
+    fn from(state: [u32; STATE_WORDS]) -> Core<R> {
         Self {
             state,
             rounds: PhantomData,

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -58,7 +58,7 @@
 
 pub use cipher;
 
-mod block;
+mod core;
 mod rounds;
 mod salsa;
 #[cfg(feature = "xsalsa20")]
@@ -68,7 +68,7 @@ pub use crate::salsa::{Key, Nonce, Salsa, Salsa12, Salsa20, Salsa8};
 
 #[cfg(feature = "expose-core")]
 pub use crate::{
-    block::Block,
+    core::Core,
     rounds::{R12, R20, R8},
 };
 

--- a/salsa20/src/salsa.rs
+++ b/salsa20/src/salsa.rs
@@ -5,7 +5,7 @@
 // TODO(tarcieri): figure out how to unify this with the `ctr` crate (see #95)
 
 use crate::{
-    block::Block,
+    core::Core,
     rounds::{Rounds, R12, R20, R8},
     BLOCK_SIZE,
 };
@@ -52,10 +52,10 @@ type Buffer = [u8; BLOCK_SIZE];
 ///
 /// We recommend you use the [`Salsa20`] (a.k.a. Salsa20/20) variant.
 pub struct Salsa<R: Rounds> {
-    /// Salsa block function initialized with a key and IV
-    block: Block<R>,
+    /// Salsa core function initialized with a key and IV
+    block: Core<R>,
 
-    /// Buffer containing previous block function output
+    /// Buffer containing previous output
     buffer: Buffer,
 
     /// Position within buffer, or `None` if the buffer is not in use
@@ -73,7 +73,7 @@ impl<R: Rounds> NewStreamCipher for Salsa<R> {
     type NonceSize = U8;
 
     fn new(key: &Key, nonce: &Nonce) -> Self {
-        let block = Block::new(key, nonce);
+        let block = Core::new(key, nonce);
 
         Self {
             block,

--- a/salsa20/src/xsalsa.rs
+++ b/salsa20/src/xsalsa.rs
@@ -1,6 +1,6 @@
 //! XSalsa20 is an extended nonce variant of Salsa20
 
-use crate::{block::quarter_round, Key, Nonce, Salsa20, CONSTANTS};
+use crate::{core::quarter_round, Key, Nonce, Salsa20, CONSTANTS};
 use cipher::{
     consts::{U16, U24, U32},
     generic_array::GenericArray,


### PR DESCRIPTION
For consistency, renames the "core" types of both crates to `Core`.

Previously `chacha20` used `State`, which is an odd name for a type which is stateless once initialized.

The `salsa20` used `Block`, which is inconsistent with the name of the `expose-core` feature.

Also adds a semi-hidden (i.e. not visible from https://docs.rs) `expose-core` feature to the `chacha20` crate, similar to the one in the `salsa20` crate (which is used to implement `scrypt`).