### PR TITLE
Bump `cipher` crate to v0.3.0-pre.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,16 +2,6 @@
 # It is not intended for manual editing.
 # 
 [[package]]
-name = "aes"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#882f1f14df0112470bf972a9d0b97f3871c96880"
-dependencies = [
- "cfg-if",
- "cipher",
- "opaque-debug",
-]
-
-[[package]]
 name = "blobby"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,7 +11,6 @@ checksum = "fc52553543ecb104069b0ff9e0fcc5c739ad16202935528a112d974e8f1a4ee8"
 name = "cfb-mode"
 version = "0.7.0-pre"
 dependencies = [
- "aes",
  "cipher",
  "hex-literal",
 ]
@@ -30,7 +19,6 @@ dependencies = [
 name = "cfb8"
 version = "0.7.0-pre"
 dependencies = [
- "aes",
  "cipher",
  "hex-literal",
 ]
@@ -55,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.3.0-pre"
+version = "0.3.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42848bd4f28c6e74641082fc3ca870cb5381ce08d8715045cc96ff4ca20c0bbe"
+checksum = "e067eaf9ba1497adc11bb7fb96c9aa4355ac978da0c384d27fc97866ea9e4c6b"
 dependencies = [
  "blobby",
  "generic-array",
@@ -73,7 +61,6 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 name = "ctr"
 version = "0.7.0-pre"
 dependencies = [
- "aes",
  "cipher",
  "hex-literal",
 ]
@@ -119,16 +106,9 @@ dependencies = [
 name = "ofb"
 version = "0.5.0-pre"
 dependencies = [
- "aes",
  "cipher",
  "hex-literal",
 ]
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "proc-macro-hack"
@@ -156,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "rabbit"
-version = "0.3.0-pre"
+version = "0.3.0-pre.3"
 dependencies = [
  "cipher",
  "zeroize",
@@ -237,3 +217,8 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[patch.unused]]
+name = "aes"
+version = "0.7.0-pre"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#882f1f14df0112470bf972a9d0b97f3871c96880"

--- a/benches/src/chacha20.rs
+++ b/benches/src/chacha20.rs
@@ -3,7 +3,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
 use criterion_cycles_per_byte::CyclesPerByte;
 
 use chacha20::{
-    cipher::{NewStreamCipher, SyncStreamCipher},
+    cipher::{NewCipher, StreamCipher},
     ChaCha20,
 };
 

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "0.3.0-pre"
+cipher = "0.3.0-pre.3"
 
 [dev-dependencies]
-aes = "0.7.0-pre"
-cipher = { version = "0.3.0-pre", features = ["dev"] }
+#aes = "0.7.0-pre"
+cipher = { version = "0.3.0-pre.3", features = ["dev"] }
 hex-literal = "0.2"

--- a/cfb-mode/src/lib.rs
+++ b/cfb-mode/src/lib.rs
@@ -10,7 +10,7 @@
 //! ```
 //! use aes::Aes128;
 //! use cfb_mode::Cfb;
-//! use cfb_mode::cipher::{NewStreamCipher, StreamCipher};
+//! use cfb_mode::cipher::{NewCipher, StreamCipher};
 //! use hex_literal::hex;
 //!
 //! type AesCfb = Cfb<Aes128>;
@@ -53,9 +53,8 @@
 pub use cipher;
 
 use cipher::{
-    block::{BlockCipher, BlockEncrypt, NewBlockCipher, ParBlocks},
     generic_array::{typenum::Unsigned, GenericArray},
-    stream::{FromBlockCipher, StreamCipher},
+    AsyncStreamCipher, BlockCipher, BlockEncrypt, FromBlockCipher, NewBlockCipher, ParBlocks,
 };
 use core::slice;
 
@@ -80,7 +79,7 @@ where
     }
 }
 
-impl<C: BlockCipher + BlockEncrypt> StreamCipher for Cfb<C> {
+impl<C: BlockCipher + BlockEncrypt> AsyncStreamCipher for Cfb<C> {
     fn encrypt(&mut self, mut data: &mut [u8]) {
         let bs = C::BlockSize::USIZE;
         let n = data.len();

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre"
+cipher = "=0.3.0-pre.3"
 
 [dev-dependencies]
-aes = "=0.7.0-pre"
-cipher = { version = "=0.3.0-pre", features = ["dev"] }
+#aes = "=0.7.0-pre"
+cipher = { version = "=0.3.0-pre.3", features = ["dev"] }
 hex-literal = "0.2"

--- a/cfb8/src/lib.rs
+++ b/cfb8/src/lib.rs
@@ -10,7 +10,7 @@
 //! ```
 //! use aes::Aes128;
 //! use cfb8::Cfb8;
-//! use cfb8::cipher::{NewStreamCipher, StreamCipher};
+//! use cfb8::cipher::{NewCipher, AsyncStreamCipher};
 //! use hex_literal::hex;
 //!
 //! type AesCfb8 = Cfb8<Aes128>;
@@ -54,9 +54,8 @@
 pub use cipher;
 
 use cipher::{
-    block::{BlockCipher, BlockEncrypt, NewBlockCipher},
-    generic_array::GenericArray,
-    stream::{FromBlockCipher, Nonce, StreamCipher},
+    generic_array::GenericArray, AsyncStreamCipher, BlockCipher, BlockEncrypt, FromBlockCipher,
+    NewBlockCipher, Nonce,
 };
 
 /// CFB self-synchronizing stream cipher instance.
@@ -80,7 +79,7 @@ where
     }
 }
 
-impl<C: BlockCipher + BlockEncrypt> StreamCipher for Cfb8<C> {
+impl<C: BlockCipher + BlockEncrypt> AsyncStreamCipher for Cfb8<C> {
     fn encrypt(&mut self, data: &mut [u8]) {
         let mut iv = self.iv.clone();
         let n = iv.len();

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2018"
 
 [dependencies]
 cfg-if = "1"
-cipher = { version = "=0.3.0-pre", optional = true }
+cipher = { version = "=0.3.0-pre.3", optional = true }
 rand_core = { version = "0.5", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
@@ -26,7 +26,7 @@ zeroize = { version = "1", optional = true, default-features = false }
 cpuid-bool = "0.2"
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre", features = ["dev"] }
+cipher = { version = "=0.3.0-pre.3", features = ["dev"] }
 hex-literal = "0.2"
 
 [features]

--- a/chacha20/src/legacy.rs
+++ b/chacha20/src/legacy.rs
@@ -3,14 +3,13 @@
 use crate::chacha::{ChaCha20, Key};
 use cipher::{
     consts::{U32, U8},
-    stream::{
-        LoopError, NewStreamCipher, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
-    },
+    errors::{LoopError, OverflowError},
+    NewCipher, SeekNum, StreamCipher, StreamCipherSeek,
 };
 
 /// Size of the nonce for the legacy ChaCha20 stream cipher
 #[cfg_attr(docsrs, doc(cfg(feature = "legacy")))]
-pub type LegacyNonce = cipher::stream::Nonce<ChaCha20Legacy>;
+pub type LegacyNonce = cipher::Nonce<ChaCha20Legacy>;
 
 /// The ChaCha20 stream cipher (legacy "djb" construction with 64-bit nonce).
 ///
@@ -18,7 +17,7 @@ pub type LegacyNonce = cipher::stream::Nonce<ChaCha20Legacy>;
 #[cfg_attr(docsrs, doc(cfg(feature = "legacy")))]
 pub struct ChaCha20Legacy(ChaCha20);
 
-impl NewStreamCipher for ChaCha20Legacy {
+impl NewCipher for ChaCha20Legacy {
     /// Key size in bytes
     type KeySize = U32;
 
@@ -32,13 +31,13 @@ impl NewStreamCipher for ChaCha20Legacy {
     }
 }
 
-impl SyncStreamCipher for ChaCha20Legacy {
+impl StreamCipher for ChaCha20Legacy {
     fn try_apply_keystream(&mut self, data: &mut [u8]) -> Result<(), LoopError> {
         self.0.try_apply_keystream(data)
     }
 }
 
-impl SyncStreamCipherSeek for ChaCha20Legacy {
+impl StreamCipherSeek for ChaCha20Legacy {
     fn try_current_pos<T: SeekNum>(&self) -> Result<T, OverflowError> {
         self.0.try_current_pos()
     }

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -42,7 +42,7 @@
 //!
 //! ```
 //! use chacha20::{ChaCha20, Key, Nonce};
-//! use chacha20::cipher::{NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
+//! use chacha20::cipher::{NewCipher, StreamCipher, StreamCipherSeek};
 //!
 //! let mut data = [1, 2, 3, 4, 5, 6, 7];
 //!

--- a/chacha20/src/xchacha.rs
+++ b/chacha20/src/xchacha.rs
@@ -7,16 +7,15 @@ use crate::{
 };
 use cipher::{
     consts::{U16, U24, U32},
+    errors::{LoopError, OverflowError},
     generic_array::GenericArray,
-    stream::{
-        LoopError, NewStreamCipher, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
-    },
+    NewCipher, SeekNum, StreamCipher, StreamCipherSeek,
 };
 use core::convert::TryInto;
 
 /// EXtended ChaCha20 nonce (192-bits/24-bytes)
 #[cfg_attr(docsrs, doc(cfg(feature = "xchacha20")))]
-pub type XNonce = cipher::stream::Nonce<XChaCha20>;
+pub type XNonce = cipher::Nonce<XChaCha20>;
 
 /// XChaCha20 is a ChaCha20 variant with an extended 192-bit (24-byte) nonce.
 ///
@@ -39,7 +38,7 @@ pub type XNonce = cipher::stream::Nonce<XChaCha20>;
 #[cfg_attr(docsrs, doc(cfg(feature = "xchacha20")))]
 pub struct XChaCha20(ChaCha20);
 
-impl NewStreamCipher for XChaCha20 {
+impl NewCipher for XChaCha20 {
     /// Key size in bytes
     type KeySize = U32;
 
@@ -56,13 +55,13 @@ impl NewStreamCipher for XChaCha20 {
     }
 }
 
-impl SyncStreamCipher for XChaCha20 {
+impl StreamCipher for XChaCha20 {
     fn try_apply_keystream(&mut self, data: &mut [u8]) -> Result<(), LoopError> {
         self.0.try_apply_keystream(data)
     }
 }
 
-impl SyncStreamCipherSeek for XChaCha20 {
+impl StreamCipherSeek for XChaCha20 {
     fn try_current_pos<T: SeekNum>(&self) -> Result<T, OverflowError> {
         self.0.try_current_pos()
     }

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre"
+cipher = "=0.3.0-pre.3"
 
 [dev-dependencies]
-aes = "=0.7.0-pre"
-cipher = { version = "=0.3.0-pre", features = ["dev"] }
+#aes = "=0.7.0-pre"
+cipher = { version = "=0.3.0-pre.3", features = ["dev"] }
 hex-literal = "0.2"

--- a/ctr/src/flavors.rs
+++ b/ctr/src/flavors.rs
@@ -2,7 +2,7 @@
 
 use cipher::{
     generic_array::{typenum::U16, ArrayLength, GenericArray},
-    stream::SeekNum,
+    SeekNum,
 };
 
 mod ctr128;

--- a/ctr/src/lib.rs
+++ b/ctr/src/lib.rs
@@ -11,7 +11,7 @@
 //! # `Ctr128` Usage Example
 //!
 //! ```
-//! use ctr::cipher::stream::{NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
+//! use ctr::cipher::{NewCipher, StreamCipher, StreamCipherSeek};
 //!
 //! // `aes` crate provides AES block cipher implementation
 //! type Aes128Ctr = ctr::Ctr128BE<aes::Aes128>;
@@ -45,14 +45,13 @@
 
 pub use cipher;
 use cipher::{
-    block::{Block, BlockCipher, BlockEncrypt, ParBlocks},
+    errors::{LoopError, OverflowError},
     generic_array::{
         typenum::{Unsigned, U16},
         ArrayLength, GenericArray,
     },
-    stream::{
-        FromBlockCipher, LoopError, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
-    },
+    Block, BlockCipher, BlockEncrypt, FromBlockCipher, ParBlocks, SeekNum, StreamCipher,
+    StreamCipherSeek,
 };
 use core::fmt;
 use core::ops::Div;
@@ -145,7 +144,7 @@ where
     }
 }
 
-impl<B, F> SyncStreamCipher for Ctr<B, F>
+impl<B, F> StreamCipher for Ctr<B, F>
 where
     B: BlockEncrypt + BlockCipher<BlockSize = U16>,
     B::ParBlocks: ArrayLength<GenericArray<u8, U16>>,
@@ -210,7 +209,7 @@ where
     }
 }
 
-impl<B, F> SyncStreamCipherSeek for Ctr<B, F>
+impl<B, F> StreamCipherSeek for Ctr<B, F>
 where
     B: BlockEncrypt + BlockCipher<BlockSize = U16>,
     B::ParBlocks: ArrayLength<GenericArray<u8, U16>>,

--- a/ctr/tests/ctr128/mod.rs
+++ b/ctr/tests/ctr128/mod.rs
@@ -1,7 +1,7 @@
 type Aes128Ctr = ctr::Ctr128BE<aes::Aes128>;
 type Aes256Ctr = ctr::Ctr128BE<aes::Aes256>;
 
-cipher::stream_cipher_sync_test!(aes128_ctr_core, Aes128Ctr, "aes128-ctr");
-cipher::stream_cipher_sync_test!(aes256_ctr_core, Aes256Ctr, "aes256-ctr");
+cipher::stream_cipher_test!(aes128_ctr_core, Aes128Ctr, "aes128-ctr");
+cipher::stream_cipher_test!(aes256_ctr_core, Aes256Ctr, "aes256-ctr");
 cipher::stream_cipher_seek_test!(aes128_ctr_seek, Aes128Ctr);
 cipher::stream_cipher_seek_test!(aes256_ctr_seek, Aes256Ctr);

--- a/ctr/tests/ctr32/big_endian.rs
+++ b/ctr/tests/ctr32/big_endian.rs
@@ -1,6 +1,6 @@
 //! Counter Mode with a 32-bit big endian counter
 
-use cipher::stream::{NewStreamCipher, SyncStreamCipher};
+use cipher::{NewCipher, StreamCipher};
 use hex_literal::hex;
 
 type Aes128Ctr = ctr::Ctr32BE<aes::Aes128>;

--- a/ctr/tests/ctr32/little_endian.rs
+++ b/ctr/tests/ctr32/little_endian.rs
@@ -1,10 +1,6 @@
 //! Counter Mode with a 32-bit little endian counter
 
-use cipher::{
-    consts::U16,
-    generic_array::GenericArray,
-    stream::{NewStreamCipher, SyncStreamCipher},
-};
+use cipher::{consts::U16, generic_array::GenericArray, NewCipher, StreamCipher};
 use hex_literal::hex;
 
 type Aes128Ctr = ctr::Ctr32LE<aes::Aes128>;

--- a/hc-256/Cargo.toml
+++ b/hc-256/Cargo.toml
@@ -11,5 +11,5 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre"
+cipher = "=0.3.0-pre.3"
 zeroize = { version = "1", optional = true, default-features = false }

--- a/hc-256/src/lib.rs
+++ b/hc-256/src/lib.rs
@@ -11,9 +11,7 @@
 pub use cipher;
 
 use cipher::{
-    consts::U32,
-    generic_array::GenericArray,
-    stream::{NewStreamCipher, StreamCipher},
+    consts::U32, errors::LoopError, generic_array::GenericArray, NewCipher, StreamCipher,
 };
 
 #[cfg(cargo_feature = "zeroize")]
@@ -38,7 +36,7 @@ pub struct Hc256 {
     offset: u8,
 }
 
-impl NewStreamCipher for Hc256 {
+impl NewCipher for Hc256 {
     /// Key size in bytes
     type KeySize = U32;
     /// Nonce size in bytes
@@ -52,12 +50,9 @@ impl NewStreamCipher for Hc256 {
 }
 
 impl StreamCipher for Hc256 {
-    fn encrypt(&mut self, data: &mut [u8]) {
+    fn try_apply_keystream(&mut self, data: &mut [u8]) -> Result<(), LoopError> {
         self.process(data);
-    }
-
-    fn decrypt(&mut self, data: &mut [u8]) {
-        self.process(data);
+        Ok(())
     }
 }
 

--- a/hc-256/tests/lib.rs
+++ b/hc-256/tests/lib.rs
@@ -1,7 +1,4 @@
-use cipher::{
-    generic_array::GenericArray,
-    stream::{NewStreamCipher, StreamCipher},
-};
+use cipher::{generic_array::GenericArray, NewCipher, StreamCipher};
 use hc_256::Hc256;
 
 #[cfg(test)]
@@ -59,7 +56,7 @@ fn test_key0_iv0() {
     );
     let mut buf = [0; 64];
 
-    cipher.encrypt(&mut buf);
+    cipher.apply_keystream(&mut buf);
 
     for i in 0..64 {
         assert_eq!(buf[i], EXPECTED_PAPER_KEY0_IV0[i])
@@ -75,8 +72,8 @@ fn test_key0_iv0_offset_1() {
     let mut buf1 = [0; 1];
     let mut buf2 = [0; 63];
 
-    cipher.encrypt(&mut buf1);
-    cipher.encrypt(&mut buf2);
+    cipher.apply_keystream(&mut buf1);
+    cipher.apply_keystream(&mut buf2);
 
     for i in 0..1 {
         assert_eq!(buf1[i], EXPECTED_PAPER_KEY0_IV0[i])
@@ -96,8 +93,8 @@ fn test_key0_iv0_offset_2() {
     let mut buf1 = [0; 2];
     let mut buf2 = [0; 62];
 
-    cipher.encrypt(&mut buf1);
-    cipher.encrypt(&mut buf2);
+    cipher.apply_keystream(&mut buf1);
+    cipher.apply_keystream(&mut buf2);
 
     for i in 0..2 {
         assert_eq!(buf1[i], EXPECTED_PAPER_KEY0_IV0[i])
@@ -117,8 +114,8 @@ fn test_key0_iv0_offset_3() {
     let mut buf1 = [0; 3];
     let mut buf2 = [0; 61];
 
-    cipher.encrypt(&mut buf1);
-    cipher.encrypt(&mut buf2);
+    cipher.apply_keystream(&mut buf1);
+    cipher.apply_keystream(&mut buf2);
 
     for i in 0..3 {
         assert_eq!(buf1[i], EXPECTED_PAPER_KEY0_IV0[i])
@@ -138,8 +135,8 @@ fn test_key0_iv0_offset_4() {
     let mut buf1 = [0; 4];
     let mut buf2 = [0; 60];
 
-    cipher.encrypt(&mut buf1);
-    cipher.encrypt(&mut buf2);
+    cipher.apply_keystream(&mut buf1);
+    cipher.apply_keystream(&mut buf2);
 
     for i in 0..4 {
         assert_eq!(buf1[i], EXPECTED_PAPER_KEY0_IV0[i])
@@ -159,8 +156,8 @@ fn test_key0_iv0_offset_5() {
     let mut buf1 = [0; 5];
     let mut buf2 = [0; 59];
 
-    cipher.encrypt(&mut buf1);
-    cipher.encrypt(&mut buf2);
+    cipher.apply_keystream(&mut buf1);
+    cipher.apply_keystream(&mut buf2);
 
     for i in 0..5 {
         assert_eq!(buf1[i], EXPECTED_PAPER_KEY0_IV0[i])
@@ -180,8 +177,8 @@ fn test_key0_iv0_offset_6() {
     let mut buf1 = [0; 6];
     let mut buf2 = [0; 58];
 
-    cipher.encrypt(&mut buf1);
-    cipher.encrypt(&mut buf2);
+    cipher.apply_keystream(&mut buf1);
+    cipher.apply_keystream(&mut buf2);
 
     for i in 0..6 {
         assert_eq!(buf1[i], EXPECTED_PAPER_KEY0_IV0[i])
@@ -201,8 +198,8 @@ fn test_key0_iv0_offset_7() {
     let mut buf1 = [0; 7];
     let mut buf2 = [0; 57];
 
-    cipher.encrypt(&mut buf1);
-    cipher.encrypt(&mut buf2);
+    cipher.apply_keystream(&mut buf1);
+    cipher.apply_keystream(&mut buf2);
 
     for i in 0..7 {
         assert_eq!(buf1[i], EXPECTED_PAPER_KEY0_IV0[i])
@@ -222,8 +219,8 @@ fn test_key0_iv0_offset_8() {
     let mut buf1 = [0; 8];
     let mut buf2 = [0; 56];
 
-    cipher.encrypt(&mut buf1);
-    cipher.encrypt(&mut buf2);
+    cipher.apply_keystream(&mut buf1);
+    cipher.apply_keystream(&mut buf2);
 
     for i in 0..8 {
         assert_eq!(buf1[i], EXPECTED_PAPER_KEY0_IV0[i])
@@ -242,7 +239,7 @@ fn test_key1_iv0() {
     );
     let mut buf = [0; 64];
 
-    cipher.encrypt(&mut buf);
+    cipher.apply_keystream(&mut buf);
 
     for i in 0..64 {
         assert_eq!(buf[i], EXPECTED_PAPER_KEY1_IV0[i])
@@ -257,7 +254,7 @@ fn test_key0_iv1() {
     );
     let mut buf = [0; 64];
 
-    cipher.encrypt(&mut buf);
+    cipher.apply_keystream(&mut buf);
 
     for i in 0..64 {
         assert_eq!(buf[i], EXPECTED_PAPER_KEY0_IV1[i])

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre"
+cipher = "=0.3.0-pre.3"
 
 [dev-dependencies]
-aes = "=0.7.0-pre"
-cipher = { version = "=0.3.0-pre", features = ["dev"] }
+#aes = "=0.7.0-pre"
+cipher = { version = "=0.3.0-pre.3", features = ["dev"] }
 hex-literal = "0.2"

--- a/ofb/src/lib.rs
+++ b/ofb/src/lib.rs
@@ -11,7 +11,7 @@
 //! use aes::Aes128;
 //! use hex_literal::hex;
 //! use ofb::Ofb;
-//! use ofb::cipher::{NewStreamCipher, SyncStreamCipher};
+//! use ofb::cipher::{NewCipher, StreamCipher};
 //!
 //! type AesOfb = Ofb<Aes128>;
 //!
@@ -56,9 +56,8 @@
 pub use cipher;
 
 use cipher::{
-    block::{Block, BlockCipher, BlockEncrypt, NewBlockCipher},
-    generic_array::typenum::Unsigned,
-    stream::{FromBlockCipher, LoopError, Nonce, SyncStreamCipher},
+    errors::LoopError, generic_array::typenum::Unsigned, Block, BlockCipher, BlockEncrypt,
+    FromBlockCipher, NewBlockCipher, Nonce, StreamCipher,
 };
 
 /// OFB self-synchronizing stream cipher instance.
@@ -86,7 +85,7 @@ where
     }
 }
 
-impl<C: BlockCipher + BlockEncrypt> SyncStreamCipher for Ofb<C> {
+impl<C: BlockCipher + BlockEncrypt> StreamCipher for Ofb<C> {
     fn try_apply_keystream(&mut self, mut data: &mut [u8]) -> Result<(), LoopError> {
         let bs = C::BlockSize::to_usize();
         let n = data.len();

--- a/ofb/tests/lib.rs
+++ b/ofb/tests/lib.rs
@@ -1,1 +1,1 @@
-cipher::stream_cipher_sync_test!(ofb_aes128, ofb::Ofb<aes::Aes128>, "aes128");
+cipher::stream_cipher_test!(ofb_aes128, ofb::Ofb<aes::Aes128>, "aes128");

--- a/rabbit/Cargo.toml
+++ b/rabbit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rabbit"
 description = "An implementation of the Rabbit Stream Cipher Algorithm"
-version = "0.3.0-pre"
+version = "0.3.0-pre.3"
 authors = ["AIkorsky <aikorsky@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RustCrypto/stream-ciphers"
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre"
+cipher = "=0.3.0-pre.3"
 zeroize = { version = "1", optional = true, default-features = false, features = ["zeroize_derive"] }
 
 [features]

--- a/rabbit/src/lib.rs
+++ b/rabbit/src/lib.rs
@@ -2,15 +2,16 @@
 //!
 //! [1]: https://tools.ietf.org/html/rfc4503#section-2.3
 
+#![no_std]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
-#![no_std]
 
 pub use cipher;
+
 use cipher::{
     consts::{U16, U8},
-    stream::LoopError,
-    NewStreamCipher, SyncStreamCipher,
+    errors::LoopError,
+    NewCipher, StreamCipher,
 };
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -33,7 +34,7 @@ const A: [u32; 8] = [
 ];
 
 /// Rabbit Stream Cipher Key.
-pub type Key = cipher::stream::Key<Rabbit>;
+pub type Key = cipher::CipherKey<Rabbit>;
 
 /// Rabbit Stream Cipher Initialization Vector. See RFC 4503 3.2. Initialization Vector (page 5).
 ///
@@ -48,7 +49,7 @@ pub type Key = cipher::stream::Key<Rabbit>;
 /// > under the same key.
 ///
 /// [4]: http://eprint.iacr.org/2005/007.pdf
-pub type Iv = cipher::stream::Nonce<Rabbit>;
+pub type Iv = cipher::Nonce<Rabbit>;
 
 /// RFC 4503. 2.2.  Inner State (page 2).
 #[derive(Default, Clone, PartialEq, Eq, Hash)]
@@ -400,16 +401,16 @@ impl Rabbit {
     }
 }
 
-impl NewStreamCipher for Rabbit {
+impl NewCipher for Rabbit {
     type KeySize = U16;
     type NonceSize = U8;
 
-    fn new(key: &cipher::stream::Key<Self>, iv: &cipher::stream::Nonce<Self>) -> Self {
+    fn new(key: &cipher::CipherKey<Self>, iv: &cipher::Nonce<Self>) -> Self {
         Self::setup((*key).into(), (*iv).into())
     }
 }
 
-impl SyncStreamCipher for Rabbit {
+impl StreamCipher for Rabbit {
     fn try_apply_keystream(&mut self, data: &mut [u8]) -> Result<(), LoopError> {
         if self.encrypt_inplace(data) {
             Ok(())

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre"
+cipher = "=0.3.0-pre.3"
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre", features = ["dev"] }
+cipher = { version = "=0.3.0-pre.3", features = ["dev"] }
 
 [features]
 default = ["xsalsa20"]

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! ```
 //! use salsa20::{Salsa20, Key, Nonce};
-//! use salsa20::cipher::{NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
+//! use salsa20::cipher::{NewCipher, StreamCipher, StreamCipherSeek};
 //!
 //! let mut data = [1, 2, 3, 4, 5, 6, 7];
 //!

--- a/salsa20/src/salsa.rs
+++ b/salsa20/src/salsa.rs
@@ -11,9 +11,8 @@ use crate::{
 };
 use cipher::{
     consts::{U32, U8},
-    stream::{
-        LoopError, NewStreamCipher, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
-    },
+    errors::{LoopError, OverflowError},
+    NewCipher, SeekNum, StreamCipher, StreamCipherSeek,
 };
 use core::fmt;
 
@@ -25,12 +24,12 @@ use cipher::generic_array::GenericArray;
 /// Implemented as an alias for [`GenericArray`].
 ///
 /// (NOTE: all three round variants use the same key size)
-pub type Key = cipher::stream::Key<Salsa20>;
+pub type Key = cipher::CipherKey<Salsa20>;
 
 /// Nonce type.
 ///
 /// Implemented as an alias for [`GenericArray`].
-pub type Nonce = cipher::stream::Nonce<Salsa20>;
+pub type Nonce = cipher::Nonce<Salsa20>;
 
 /// Salsa20/8 stream cipher
 /// (reduced-round variant of Salsa20 with 8 rounds, *not recommended*)
@@ -65,7 +64,7 @@ pub struct Salsa<R: Rounds> {
     counter: u64,
 }
 
-impl<R: Rounds> NewStreamCipher for Salsa<R> {
+impl<R: Rounds> NewCipher for Salsa<R> {
     /// Key size in bytes
     type KeySize = U32;
 
@@ -84,7 +83,7 @@ impl<R: Rounds> NewStreamCipher for Salsa<R> {
     }
 }
 
-impl<R: Rounds> SyncStreamCipher for Salsa<R> {
+impl<R: Rounds> StreamCipher for Salsa<R> {
     fn try_apply_keystream(&mut self, mut data: &mut [u8]) -> Result<(), LoopError> {
         self.check_data_len(data)?;
         let pos = self.buffer_pos as usize;
@@ -125,7 +124,7 @@ impl<R: Rounds> SyncStreamCipher for Salsa<R> {
     }
 }
 
-impl<R: Rounds> SyncStreamCipherSeek for Salsa<R> {
+impl<R: Rounds> StreamCipherSeek for Salsa<R> {
     fn try_current_pos<T: SeekNum>(&self) -> Result<T, OverflowError> {
         T::from_block_byte(self.counter, self.buffer_pos, BLOCK_SIZE as u8)
     }

--- a/salsa20/src/xsalsa.rs
+++ b/salsa20/src/xsalsa.rs
@@ -3,16 +3,15 @@
 use crate::{core::quarter_round, Key, Nonce, Salsa20, CONSTANTS};
 use cipher::{
     consts::{U16, U24, U32},
+    errors::{LoopError, OverflowError},
     generic_array::GenericArray,
-    stream::{
-        LoopError, NewStreamCipher, OverflowError, SeekNum, SyncStreamCipher, SyncStreamCipherSeek,
-    },
+    NewCipher, SeekNum, StreamCipher, StreamCipherSeek,
 };
 use core::convert::TryInto;
 
 /// EXtended Salsa20 nonce (192-bit/24-byte)
 #[cfg_attr(docsrs, doc(cfg(feature = "xsalsa20")))]
-pub type XNonce = cipher::stream::Nonce<XSalsa20>;
+pub type XNonce = cipher::Nonce<XSalsa20>;
 
 /// XSalsa20 is a Salsa20 variant with an extended 192-bit (24-byte) nonce.
 ///
@@ -25,7 +24,7 @@ pub type XNonce = cipher::stream::Nonce<XSalsa20>;
 #[cfg_attr(docsrs, doc(cfg(feature = "xsalsa20")))]
 pub struct XSalsa20(Salsa20);
 
-impl NewStreamCipher for XSalsa20 {
+impl NewCipher for XSalsa20 {
     /// Key size in bytes
     type KeySize = U32;
 
@@ -50,13 +49,13 @@ impl NewStreamCipher for XSalsa20 {
     }
 }
 
-impl SyncStreamCipher for XSalsa20 {
+impl StreamCipher for XSalsa20 {
     fn try_apply_keystream(&mut self, data: &mut [u8]) -> Result<(), LoopError> {
         self.0.try_apply_keystream(data)
     }
 }
 
-impl SyncStreamCipherSeek for XSalsa20 {
+impl StreamCipherSeek for XSalsa20 {
     fn try_current_pos<T: SeekNum>(&self) -> Result<T, OverflowError> {
         self.0.try_current_pos()
     }

--- a/salsa20/tests/lib.rs
+++ b/salsa20/tests/lib.rs
@@ -1,9 +1,6 @@
 //! Salsa20 tests
 
-use cipher::{
-    generic_array::GenericArray,
-    stream::{NewStreamCipher, StreamCipher, SyncStreamCipherSeek},
-};
+use cipher::{generic_array::GenericArray, NewCipher, StreamCipher, StreamCipherSeek};
 use salsa20::Salsa20;
 #[cfg(feature = "xsalsa20")]
 use salsa20::XSalsa20;
@@ -124,7 +121,7 @@ fn salsa20_key1_iv0() {
     let mut cipher = Salsa20::new(&GenericArray::from(KEY1), &GenericArray::from(IV0));
     let mut buf = [0; 64];
 
-    cipher.encrypt(&mut buf);
+    cipher.apply_keystream(&mut buf);
 
     for i in 0..64 {
         assert_eq!(buf[i], EXPECTED_KEY1_IV0[i])
@@ -136,7 +133,7 @@ fn salsa20_key0_iv1() {
     let mut cipher = Salsa20::new(&GenericArray::from(KEY0), &GenericArray::from(IV1));
     let mut buf = [0; 64];
 
-    cipher.encrypt(&mut buf);
+    cipher.apply_keystream(&mut buf);
 
     for i in 0..64 {
         assert_eq!(buf[i], EXPECTED_KEY0_IV1[i])
@@ -148,7 +145,7 @@ fn salsa20_key0_ivhi() {
     let mut cipher = Salsa20::new(&GenericArray::from(KEY0), &GenericArray::from(IVHI));
     let mut buf = [0; 64];
 
-    cipher.encrypt(&mut buf);
+    cipher.apply_keystream(&mut buf);
 
     for i in 0..64 {
         assert_eq!(buf[i], EXPECTED_KEY0_IVHI[i])
@@ -160,7 +157,7 @@ fn salsa20_long() {
     let mut cipher = Salsa20::new(&GenericArray::from(KEY_LONG), &GenericArray::from(IV_LONG));
     let mut buf = [0; 256];
 
-    cipher.encrypt(&mut buf);
+    cipher.apply_keystream(&mut buf);
 
     for i in 0..256 {
         assert_eq!(buf[i], EXPECTED_LONG[i])
@@ -178,8 +175,8 @@ fn salsa20_offsets() {
                 let mut buf = [0; 256];
 
                 cipher.seek(idx as u64);
-                cipher.encrypt(&mut buf[idx..middle]);
-                cipher.encrypt(&mut buf[middle..last]);
+                cipher.apply_keystream(&mut buf[idx..middle]);
+                cipher.apply_keystream(&mut buf[middle..last]);
 
                 for k in idx..last {
                     assert_eq!(buf[k], EXPECTED_LONG[k])
@@ -197,7 +194,7 @@ fn xsalsa20_encrypt_zeros() {
 
     let mut cipher = XSalsa20::new(&key, &iv);
     let mut buf = [0; 64];
-    cipher.encrypt(&mut buf);
+    cipher.apply_keystream(&mut buf);
 
     for i in 0..64 {
         assert_eq!(buf[i], EXPECTED_XSALSA20_ZEROS[i]);
@@ -212,7 +209,7 @@ fn xsalsa20_encrypt_hello_world() {
 
     let mut cipher = XSalsa20::new(&key, &iv);
     let mut buf = *b"Hello world!";
-    cipher.encrypt(&mut buf);
+    cipher.apply_keystream(&mut buf);
 
     assert_eq!(buf, EXPECTED_XSALSA20_HELLO_WORLD);
 }


### PR DESCRIPTION
Implements the changes from:

https://github.com/RustCrypto/traits/pull/435

Unfortunately there's a circular dependency with `aes`, which now pulls in `ctr`, so the tests which depend on AES are failing.

The plan is to land these changes first, then update the `block-ciphers` repository, then circle back and update the `aes` crate dependencies used in this repo.