### PR TITLE
ctr v0.7.0-pre.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "ctr"
-version = "0.7.0-pre"
+version = "0.7.0-pre.2"
 dependencies = [
  "cipher",
  "hex-literal",

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctr"
-version = "0.7.0-pre"
+version = "0.7.0-pre.2"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "CTR block mode of operation"


### PR DESCRIPTION
Note: the tests are presently failing due to a circular dependency on `aes`, but this release is needed to update `aes` to resolve that problem.

Longer term we should look at ways of eliminating this circular dependency.