### PR TITLE
Enable `aes` dev-dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,6 +2,17 @@
 # It is not intended for manual editing.
 # 
 [[package]]
+name = "aes"
+version = "0.7.0-pre"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#dc25438ef149bc7d8d747c7bf87e605295990bde"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpuid-bool",
+ "opaque-debug",
+]
+
+[[package]]
 name = "blobby"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11,6 +22,7 @@ checksum = "fc52553543ecb104069b0ff9e0fcc5c739ad16202935528a112d974e8f1a4ee8"
 name = "cfb-mode"
 version = "0.7.0-pre"
 dependencies = [
+ "aes",
  "cipher",
  "hex-literal",
 ]
@@ -19,6 +31,7 @@ dependencies = [
 name = "cfb8"
 version = "0.7.0-pre"
 dependencies = [
+ "aes",
  "cipher",
  "hex-literal",
 ]
@@ -61,6 +74,7 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 name = "ctr"
 version = "0.7.0-pre.2"
 dependencies = [
+ "aes",
  "cipher",
  "hex-literal",
 ]
@@ -106,15 +120,22 @@ dependencies = [
 name = "ofb"
 version = "0.5.0-pre"
 dependencies = [
+ "aes",
  "cipher",
  "hex-literal",
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.18"
+name = "opaque-debug"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -127,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
 ]
@@ -158,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.45"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9c5432ff16d6152371f808fb5a871cd67368171b09bb21b43df8e4a47a3556"
+checksum = "a9802ddde94170d186eeee5005b798d9c159fa970403f1be19976d0cfb939b72"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -217,8 +238,3 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[patch.unused]]
-name = "aes"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#882f1f14df0112470bf972a9d0b97f3871c96880"

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -15,6 +15,6 @@ edition = "2018"
 cipher = "0.3.0-pre.3"
 
 [dev-dependencies]
-#aes = "0.7.0-pre"
+aes = "0.7.0-pre"
 cipher = { version = "0.3.0-pre.3", features = ["dev"] }
 hex-literal = "0.2"

--- a/cfb-mode/src/lib.rs
+++ b/cfb-mode/src/lib.rs
@@ -10,7 +10,7 @@
 //! ```
 //! use aes::Aes128;
 //! use cfb_mode::Cfb;
-//! use cfb_mode::cipher::{NewCipher, StreamCipher};
+//! use cfb_mode::cipher::{NewCipher, AsyncStreamCipher};
 //! use hex_literal::hex;
 //!
 //! type AesCfb = Cfb<Aes128>;

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -15,6 +15,6 @@ edition = "2018"
 cipher = "=0.3.0-pre.3"
 
 [dev-dependencies]
-#aes = "=0.7.0-pre"
+aes = "=0.7.0-pre"
 cipher = { version = "=0.3.0-pre.3", features = ["dev"] }
 hex-literal = "0.2"

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -15,6 +15,6 @@ edition = "2018"
 cipher = "=0.3.0-pre.3"
 
 [dev-dependencies]
-#aes = "=0.7.0-pre"
+aes = "=0.7.0-pre"
 cipher = { version = "=0.3.0-pre.3", features = ["dev"] }
 hex-literal = "0.2"

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -15,6 +15,6 @@ edition = "2018"
 cipher = "=0.3.0-pre.3"
 
 [dev-dependencies]
-#aes = "=0.7.0-pre"
+aes = "=0.7.0-pre"
 cipher = { version = "=0.3.0-pre.3", features = ["dev"] }
 hex-literal = "0.2"


### PR DESCRIPTION
This commit completes working through upgrading the `cipher` crate with circular dependencies between `aes` and `ctr`.

Now that RustCrypto/block-ciphers#217 it's possible to complete the `cipher` crate upgrade started in #205.

All tests are now passing again.