### PR TITLE
Bump `cipher` crate to v0.3.0-pre.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,17 +2,6 @@
 # It is not intended for manual editing.
 # 
 [[package]]
-name = "aes"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#dc25438ef149bc7d8d747c7bf87e605295990bde"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpuid-bool",
- "opaque-debug",
-]
-
-[[package]]
 name = "blobby"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,7 +11,6 @@ checksum = "fc52553543ecb104069b0ff9e0fcc5c739ad16202935528a112d974e8f1a4ee8"
 name = "cfb-mode"
 version = "0.7.0-pre"
 dependencies = [
- "aes",
  "cipher",
  "hex-literal",
 ]
@@ -31,7 +19,6 @@ dependencies = [
 name = "cfb8"
 version = "0.7.0-pre"
 dependencies = [
- "aes",
  "cipher",
  "hex-literal",
 ]
@@ -56,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.3.0-pre.3"
+version = "0.3.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e067eaf9ba1497adc11bb7fb96c9aa4355ac978da0c384d27fc97866ea9e4c6b"
+checksum = "e1db53c34251ece12ba40366dd5ece6dc5672296d7fb34f7b1791e8f0d449e69"
 dependencies = [
  "blobby",
  "generic-array",
@@ -74,7 +61,6 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 name = "ctr"
 version = "0.7.0-pre.2"
 dependencies = [
- "aes",
  "cipher",
  "hex-literal",
 ]
@@ -120,16 +106,9 @@ dependencies = [
 name = "ofb"
 version = "0.5.0-pre"
 dependencies = [
- "aes",
  "cipher",
  "hex-literal",
 ]
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "proc-macro-hack"
@@ -157,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "rabbit"
-version = "0.3.0-pre.3"
+version = "0.3.0-pre.4"
 dependencies = [
  "cipher",
  "zeroize",
@@ -238,3 +217,8 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[patch.unused]]
+name = "aes"
+version = "0.7.0-pre"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#dc25438ef149bc7d8d747c7bf87e605295990bde"

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "0.3.0-pre.3"
+cipher = "0.3.0-pre.4"
 
 [dev-dependencies]
-aes = "0.7.0-pre"
-cipher = { version = "0.3.0-pre.3", features = ["dev"] }
+#aes = "0.7.0-pre"
+cipher = { version = "0.3.0-pre.4", features = ["dev"] }
 hex-literal = "0.2"

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre.3"
+cipher = "=0.3.0-pre.4"
 
 [dev-dependencies]
-aes = "=0.7.0-pre"
-cipher = { version = "=0.3.0-pre.3", features = ["dev"] }
+#aes = "=0.7.0-pre"
+cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
 hex-literal = "0.2"

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2018"
 
 [dependencies]
 cfg-if = "1"
-cipher = { version = "=0.3.0-pre.3", optional = true }
+cipher = { version = "=0.3.0-pre.4", optional = true }
 rand_core = { version = "0.5", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
@@ -26,7 +26,7 @@ zeroize = { version = "1", optional = true, default-features = false }
 cpuid-bool = "0.2"
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre.3", features = ["dev"] }
+cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
 hex-literal = "0.2"
 
 [features]

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre.3"
+cipher = "=0.3.0-pre.4"
 
 [dev-dependencies]
-aes = "=0.7.0-pre"
-cipher = { version = "=0.3.0-pre.3", features = ["dev"] }
+#aes = "=0.7.0-pre"
+cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
 hex-literal = "0.2"

--- a/hc-256/Cargo.toml
+++ b/hc-256/Cargo.toml
@@ -11,5 +11,5 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre.3"
+cipher = "=0.3.0-pre.4"
 zeroize = { version = "1", optional = true, default-features = false }

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre.3"
+cipher = "=0.3.0-pre.4"
 
 [dev-dependencies]
-aes = "=0.7.0-pre"
-cipher = { version = "=0.3.0-pre.3", features = ["dev"] }
+#aes = "=0.7.0-pre"
+cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
 hex-literal = "0.2"

--- a/rabbit/Cargo.toml
+++ b/rabbit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rabbit"
 description = "An implementation of the Rabbit Stream Cipher Algorithm"
-version = "0.3.0-pre.3"
+version = "0.3.0-pre.4"
 authors = ["AIkorsky <aikorsky@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RustCrypto/stream-ciphers"
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre.3"
+cipher = "=0.3.0-pre.4"
 zeroize = { version = "1", optional = true, default-features = false, features = ["zeroize_derive"] }
 
 [features]

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre.3"
+cipher = "=0.3.0-pre.4"
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre.3", features = ["dev"] }
+cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
 
 [features]
 default = ["xsalsa20"]


### PR DESCRIPTION
Note: this commit disables the (circular) `aes` dependency, so AES-related tests will fail until the `aes` crate can be updated to use the new `ctr` crate.