### PR TITLE
Re-enable `aes` dev-dependencies (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,6 +2,17 @@
 # It is not intended for manual editing.
 # 
 [[package]]
+name = "aes"
+version = "0.7.0-pre"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#3215a921f894f533882dc1a3cf55242237fca4ed"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpuid-bool",
+ "opaque-debug",
+]
+
+[[package]]
 name = "blobby"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11,6 +22,7 @@ checksum = "fc52553543ecb104069b0ff9e0fcc5c739ad16202935528a112d974e8f1a4ee8"
 name = "cfb-mode"
 version = "0.7.0-pre"
 dependencies = [
+ "aes",
  "cipher",
  "hex-literal",
 ]
@@ -19,6 +31,7 @@ dependencies = [
 name = "cfb8"
 version = "0.7.0-pre"
 dependencies = [
+ "aes",
  "cipher",
  "hex-literal",
 ]
@@ -61,6 +74,7 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 name = "ctr"
 version = "0.7.0-pre.3"
 dependencies = [
+ "aes",
  "cipher",
  "hex-literal",
 ]
@@ -106,9 +120,16 @@ dependencies = [
 name = "ofb"
 version = "0.5.0-pre"
 dependencies = [
+ "aes",
  "cipher",
  "hex-literal",
 ]
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "proc-macro-hack"
@@ -217,8 +238,3 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[patch.unused]]
-name = "aes"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#dc25438ef149bc7d8d747c7bf87e605295990bde"

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -15,6 +15,6 @@ edition = "2018"
 cipher = "0.3.0-pre.4"
 
 [dev-dependencies]
-#aes = "0.7.0-pre"
+aes = "0.7.0-pre"
 cipher = { version = "0.3.0-pre.4", features = ["dev"] }
 hex-literal = "0.2"

--- a/cfb-mode/src/lib.rs
+++ b/cfb-mode/src/lib.rs
@@ -26,14 +26,14 @@
 //!
 //! let mut data = plaintext.to_vec();
 //! // encrypt plaintext
-//! AesCfb::new_var(key, iv).unwrap().encrypt(&mut data);
+//! AesCfb::new_from_slices(key, iv).unwrap().encrypt(&mut data);
 //! assert_eq!(data, &ciphertext[..]);
 //! // and decrypt it back
-//! AesCfb::new_var(key, iv).unwrap().decrypt(&mut data);
+//! AesCfb::new_from_slices(key, iv).unwrap().decrypt(&mut data);
 //! assert_eq!(data, &plaintext[..]);
 //!
 //! // CFB mode can be used with streaming messages
-//! let mut cipher = AesCfb::new_var(key, iv).unwrap();
+//! let mut cipher = AesCfb::new_from_slices(key, iv).unwrap();
 //! for chunk in data.chunks_mut(3) {
 //!     cipher.encrypt(chunk);
 //! }

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -15,6 +15,6 @@ edition = "2018"
 cipher = "=0.3.0-pre.4"
 
 [dev-dependencies]
-#aes = "=0.7.0-pre"
+aes = "=0.7.0-pre"
 cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
 hex-literal = "0.2"

--- a/cfb8/src/lib.rs
+++ b/cfb8/src/lib.rs
@@ -26,14 +26,14 @@
 //!
 //! let mut data = plaintext.to_vec();
 //! // encrypt plaintext
-//! AesCfb8::new_var(key, iv).unwrap().encrypt(&mut data);
+//! AesCfb8::new_from_slices(key, iv).unwrap().encrypt(&mut data);
 //! assert_eq!(data, &ciphertext[..]);
 //! // and decrypt it back
-//! AesCfb8::new_var(key, iv).unwrap().decrypt(&mut data);
+//! AesCfb8::new_from_slices(key, iv).unwrap().decrypt(&mut data);
 //! assert_eq!(data, &plaintext[..]);
 //!
 //! // CFB mode can be used with streaming messages
-//! let mut cipher = AesCfb8::new_var(key, iv).unwrap();
+//! let mut cipher = AesCfb8::new_from_slices(key, iv).unwrap();
 //! for chunk in data.chunks_mut(3) {
 //!     cipher.encrypt(chunk);
 //! }

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -15,6 +15,6 @@ edition = "2018"
 cipher = "=0.3.0-pre.4"
 
 [dev-dependencies]
-#aes = "=0.7.0-pre"
+aes = "=0.7.0-pre"
 cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
 hex-literal = "0.2"

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -15,6 +15,6 @@ edition = "2018"
 cipher = "=0.3.0-pre.4"
 
 [dev-dependencies]
-#aes = "=0.7.0-pre"
+aes = "=0.7.0-pre"
 cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
 hex-literal = "0.2"

--- a/ofb/src/lib.rs
+++ b/ofb/src/lib.rs
@@ -26,16 +26,16 @@
 //!
 //! let mut buffer = plaintext.to_vec();
 //! // create cipher instance
-//! let mut cipher = AesOfb::new_var(key, iv).unwrap();
+//! let mut cipher = AesOfb::new_from_slices(key, iv).unwrap();
 //! // apply keystream (encrypt)
 //! cipher.apply_keystream(&mut buffer);
 //! assert_eq!(buffer, &ciphertext[..]);
 //! // and decrypt it back
-//! AesOfb::new_var(key, iv).unwrap().apply_keystream(&mut buffer);
+//! AesOfb::new_from_slices(key, iv).unwrap().apply_keystream(&mut buffer);
 //! assert_eq!(buffer, &plaintext[..]);
 //!
 //! // OFB mode can be used with streaming messages
-//! let mut cipher = AesOfb::new_var(key, iv).unwrap();
+//! let mut cipher = AesOfb::new_from_slices(key, iv).unwrap();
 //! for chunk in buffer.chunks_mut(3) {
 //!     cipher.apply_keystream(chunk);
 //! }


### PR DESCRIPTION
Completes the `cipher` v0.3.0-pre.4 upgrade started in #208, now that the `aes` crate has been updated as part of this PR:

https://github.com/RustCrypto/block-ciphers/pull/218