### PR TITLE
Bump `aes` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@
 [[package]]
 name = "aes"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#3215a921f894f533882dc1a3cf55242237fca4ed"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#7236bce0b75b7bcf719add5e88890bd667ebb95f"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -15,6 +15,6 @@ edition = "2018"
 cipher = "0.3.0-pre.4"
 
 [dev-dependencies]
-aes = "0.7.0-pre"
+aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
 cipher = { version = "0.3.0-pre.4", features = ["dev"] }
 hex-literal = "0.2"

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -15,6 +15,6 @@ edition = "2018"
 cipher = "=0.3.0-pre.4"
 
 [dev-dependencies]
-aes = "=0.7.0-pre"
+aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
 cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
 hex-literal = "0.2"

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -15,6 +15,6 @@ edition = "2018"
 cipher = "=0.3.0-pre.4"
 
 [dev-dependencies]
-aes = "=0.7.0-pre"
+aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
 cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
 hex-literal = "0.2"

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -15,6 +15,6 @@ edition = "2018"
 cipher = "=0.3.0-pre.4"
 
 [dev-dependencies]
-aes = "=0.7.0-pre"
+aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
 cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
 hex-literal = "0.2"


### PR DESCRIPTION
The `aes` crate is used for several tests, and just got an MSRV breaking change in RustCrypto/block-ciphers#216.

This commit bumps the git dependency to test the crates in this repo with the MSRV changes.