### PR TITLE
chacha20: make autodetect unions non-Copy; MSRV 1.49+

### DIFF
--- a/.github/workflows/chacha20.yml
+++ b/.github/workflows/chacha20.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.49.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -52,7 +52,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -60,7 +60,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -89,7 +89,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -97,7 +97,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -117,7 +117,7 @@ jobs:
       - run: cargo test --target ${{ matrix.target }} --release --features zeroize
       - run: cargo test --target ${{ matrix.target }} --release --all-features
 
-  # Tests for the portable software backend
+  # Tests for the portable software backend (i.e. `force-soft`)
   soft:
     runs-on: ubuntu-latest
     strategy:
@@ -125,7 +125,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -133,7 +133,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -159,13 +159,13 @@ jobs:
         include:
           # ARM64
           - target: aarch64-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: aarch64-unknown-linux-gnu
             rust: stable
 
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: 1.49.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
 

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -16,9 +16,10 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
-          toolchain: 1.41.0 # MSRV
+          toolchain: 1.49.0 # MSRV (highest in repo)
           components: clippy
+          override: true
+          profile: minimal
       - run: cargo clippy --all -- -D warnings
 
   rustfmt:
@@ -30,9 +31,10 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
           components: rustfmt
+          override: true
+          profile: minimal
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1

--- a/chacha20/README.md
+++ b/chacha20/README.md
@@ -62,7 +62,7 @@ stream cipher itself) are designed to execute in constant time.
 
 ## Minimum Supported Rust Version
 
-Rust **1.41** or higher.
+Rust **1.49** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -94,7 +94,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/chacha20/badge.svg
 [docs-link]: https://docs.rs/chacha20/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260049-stream-ciphers
 [build-image]: https://github.com/RustCrypto/stream-ciphers/workflows/chacha20/badge.svg?branch=master&event=push

--- a/chacha20/src/backend/avx2.rs
+++ b/chacha20/src/backend/avx2.rs
@@ -19,7 +19,7 @@ use core::arch::x86_64::*;
 
 /// The ChaCha20 core function (AVX2 accelerated implementation for x86/x86_64)
 // TODO(tarcieri): zeroize?
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub(crate) struct Core<R: Rounds> {
     v0: __m256i,
     v1: __m256i,

--- a/chacha20/src/backend/sse2.rs
+++ b/chacha20/src/backend/sse2.rs
@@ -15,7 +15,7 @@ use core::arch::x86_64::*;
 
 /// The ChaCha20 core function (SSE2 accelerated implementation for x86/x86_64)
 // TODO(tarcieri): zeroize?
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct Core<R: Rounds> {
     v0: __m128i,
     v1: __m128i,


### PR DESCRIPTION
Uses the new `core::mem::ManuallyDrop` feature to allow the inner types of unions to be non-Copy.