### PR TITLE
chacha20: add XChaCha8 and XChaCha12

### DIFF
--- a/.github/workflows/chacha20.yml
+++ b/.github/workflows/chacha20.yml
@@ -41,8 +41,8 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features cipher
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features legacy
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rng
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features xchacha20
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features cipher,force-soft,legacy,rng,xchacha20,zeroize
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features xchacha
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features cipher,force-soft,legacy,rng,xchacha,zeroize
 
   # Tests for runtime AVX2 detection
   autodetect:

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -11,7 +11,7 @@ XChaCha20, XChaCha12 and XChaCha8 stream ciphers, and also optional
 rand_core-compatible RNGs based on those ciphers.
 """
 repository = "https://github.com/RustCrypto/stream-ciphers"
-keywords = ["crypto", "stream-cipher", "chacha8", "chacha12", "xchacha20"]
+keywords = ["crypto", "stream-cipher", "chacha8", "chacha12", "chacha20", "xchacha8", "xchacha12", "xchacha20"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
 edition = "2018"
@@ -30,14 +30,14 @@ cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
 hex-literal = "0.2"
 
 [features]
-default = ["xchacha20"]
+default = ["xchacha"]
 expose-core = []
 force-soft = []
 legacy = ["cipher"]
 rng = ["rand_core"]
 std = ["cipher/std"]
-xchacha20 = ["cipher"]
+xchacha = ["cipher"]
 
 [package.metadata.docs.rs]
-features = ["legacy", "rng", "std", "xchacha20"]
+features = ["legacy", "rng", "std", "xchacha"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -7,8 +7,8 @@ description = """
 The ChaCha20 stream cipher (RFC 8439) implemented in pure Rust using traits
 from the RustCrypto `cipher` crate, with optional architecture-specific
 hardware acceleration (AVX2, SSE2). Additionally provides the ChaCha8, ChaCha12,
-and XChaCha20 stream ciphers, and also optional rand_core-compatible RNGs based
-on those ciphers.
+XChaCha20, XChaCha12 and XChaCha8 stream ciphers, and also optional
+rand_core-compatible RNGs based on those ciphers.
 """
 repository = "https://github.com/RustCrypto/stream-ciphers"
 keywords = ["crypto", "stream-cipher", "chacha8", "chacha12", "xchacha20"]

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -11,7 +11,7 @@ XChaCha20, XChaCha12 and XChaCha8 stream ciphers, and also optional
 rand_core-compatible RNGs based on those ciphers.
 """
 repository = "https://github.com/RustCrypto/stream-ciphers"
-keywords = ["crypto", "stream-cipher", "chacha8", "chacha12", "chacha20", "xchacha8", "xchacha12", "xchacha20"]
+keywords = ["crypto", "stream-cipher", "chacha8", "chacha12", "xchacha20"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
 edition = "2018"

--- a/chacha20/README.md
+++ b/chacha20/README.md
@@ -24,7 +24,7 @@ per-round diffusion at no cost to performance.
 
 This crate also contains an implementation of [XChaCha20][4]: a variant
 of ChaCha20 with an extended 192-bit (24-byte) nonce, gated under the
-`xchacha20` Cargo feature (on-by-default).
+`chacha20` Cargo feature (on-by-default).
 
 ## Implementations
 

--- a/chacha20/src/backend.rs
+++ b/chacha20/src/backend.rs
@@ -18,7 +18,7 @@ cfg_if! {
         pub(crate) use self::autodetect::BUFFER_SIZE;
         pub use self::autodetect::Core;
 
-        #[cfg(feature = "xchacha20")]
+        #[cfg(feature = "xchacha")]
         pub(crate) mod soft;
     } else {
         pub(crate) mod soft;

--- a/chacha20/src/chacha.rs
+++ b/chacha20/src/chacha.rs
@@ -22,10 +22,10 @@ use core::{
 #[cfg(docsrs)]
 use cipher::generic_array::GenericArray;
 
-/// ChaCha8 stream cipher (reduced-round variant of ChaCha20 with 8 rounds)
+/// ChaCha8 stream cipher (reduced-round variant of [`ChaCha20`] with 8 rounds)
 pub type ChaCha8 = ChaCha<R8>;
 
-/// ChaCha12 stream cipher (reduced-round variant of ChaCha20 with 12 rounds)
+/// ChaCha12 stream cipher (reduced-round variant of [`ChaCha20`] with 12 rounds)
 pub type ChaCha12 = ChaCha<R12>;
 
 /// ChaCha20 stream cipher (RFC 8439 version with 96-bit nonce)

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -14,6 +14,7 @@
 //! - [`ChaCha20Legacy`]: (gated under the `legacy` feature) "djb" variant with 64-bit nonce
 //! - [`ChaCha8`] / [`ChaCha12`]: reduced round variants of ChaCha20
 //! - [`XChaCha20`]: (gated under the `xchacha20` feature) 192-bit extended nonce variant
+//! - [`XChaCha8`] / [`XChaCha12`]: reduced round variants of XChaCha20
 //!
 //! # ⚠️ Security Warning: [Hazmat!]
 //!
@@ -106,7 +107,7 @@ pub use rng::{
 };
 
 #[cfg(feature = "xchacha20")]
-pub use self::xchacha::{XChaCha20, XNonce};
+pub use self::xchacha::{XChaCha12, XChaCha20, XChaCha8, XNonce};
 
 /// Size of a ChaCha20 block in bytes
 pub const BLOCK_SIZE: usize = 64;

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -83,7 +83,7 @@ mod legacy;
 #[cfg(feature = "rng")]
 mod rng;
 mod rounds;
-#[cfg(feature = "xchacha20")]
+#[cfg(feature = "xchacha")]
 mod xchacha;
 
 #[cfg(feature = "cipher")]
@@ -106,7 +106,7 @@ pub use rng::{
     ChaCha12Rng, ChaCha12RngCore, ChaCha20Rng, ChaCha20RngCore, ChaCha8Rng, ChaCha8RngCore,
 };
 
-#[cfg(feature = "xchacha20")]
+#[cfg(feature = "xchacha")]
 pub use self::xchacha::{XChaCha12, XChaCha20, XChaCha8, XNonce};
 
 /// Size of a ChaCha20 block in bytes

--- a/chacha20/src/xchacha.rs
+++ b/chacha20/src/xchacha.rs
@@ -1,4 +1,4 @@
-//! XChaCha20 is an extended nonce variant of ChaCha20
+//! XChaCha is an extended nonce variant of ChaCha
 
 use crate::{
     backend::soft::quarter_round,
@@ -15,7 +15,7 @@ use cipher::{
 use core::convert::TryInto;
 
 /// EXtended ChaCha20 nonce (192-bits/24-bytes)
-#[cfg_attr(docsrs, doc(cfg(feature = "xchacha20")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "xchacha")))]
 pub type XNonce = cipher::Nonce<XChaCha20>;
 
 /// XChaCha20 is a ChaCha20 variant with an extended 192-bit (24-byte) nonce.
@@ -34,20 +34,25 @@ pub type XNonce = cipher::Nonce<XChaCha20>;
 ///
 /// <https://tools.ietf.org/html/draft-arciszewski-xchacha-03>
 ///
-/// The `xchacha20` Cargo feature must be enabled in order to use this
+/// The `xchacha` Cargo feature must be enabled in order to use this
 /// (which it is by default).
-#[cfg_attr(docsrs, doc(cfg(feature = "xchacha20")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "xchacha")))]
 pub type XChaCha20 = XChaCha<R20>;
 
-/// XChaCha12 stream cipher (reduced-round variant of XChaCha20 with 12 rounds)
-#[cfg_attr(docsrs, doc(cfg(feature = "xchacha20")))]
+/// XChaCha12 stream cipher (reduced-round variant of [`XChaCha20`] with 12 rounds)
+///
+/// The `xchacha` Cargo feature must be enabled in order to use this
+/// (which it is by default).
+#[cfg_attr(docsrs, doc(cfg(feature = "xchacha")))]
 pub type XChaCha12 = XChaCha<R12>;
 
-/// XChaCha8 stream cipher (reduced-round variant of XChaCha20 with 8 rounds)
-#[cfg_attr(docsrs, doc(cfg(feature = "xchacha20")))]
+/// XChaCha8 stream cipher (reduced-round variant of [`XChaCha20`] with 8 rounds)
+///
+/// The `xchacha` Cargo feature must be enabled in order to use this
+/// (which it is by default).
+#[cfg_attr(docsrs, doc(cfg(feature = "xchacha")))]
 pub type XChaCha8 = XChaCha<R8>;
 
-#[cfg_attr(docsrs, doc(cfg(feature = "xchacha20")))]
 pub struct XChaCha<R: Rounds>(ChaCha<R>);
 
 impl<R: Rounds> NewCipher for XChaCha<R> {
@@ -83,18 +88,18 @@ impl<R: Rounds> StreamCipherSeek for XChaCha<R> {
     }
 }
 
-/// The HChaCha20 function: adapts the ChaCha20 core function in the same
-/// manner that HSalsa20 adapts the Salsa20 function.
+/// The HChaCha function: adapts the ChaCha core function in the same
+/// manner that HSalsa adapts the Salsa function.
 ///
-/// HChaCha20 takes 512-bits of input:
+/// HChaCha takes 512-bits of input:
 ///
 /// * Constants (`u32` x 4)
 /// * Key (`u32` x 8)
 /// * Nonce (`u32` x 4)
 ///
-/// It produces 256-bits of output suitable for use as a ChaCha20 key
+/// It produces 256-bits of output suitable for use as a ChaCha key
 ///
-/// For more information on HSalsa20 on which HChaCha20 is based, see:
+/// For more information on HSalsa on which HChaCha is based, see:
 ///
 /// <http://cr.yp.to/snuffle/xsalsa-20110204.pdf>
 fn hchacha<R: Rounds>(key: &Key, input: &GenericArray<u8, U16>) -> GenericArray<u8, U32> {

--- a/chacha20/tests/lib.rs
+++ b/chacha20/tests/lib.rs
@@ -6,7 +6,7 @@ use chacha20::ChaCha20;
 cipher::stream_cipher_test!(chacha20_core, ChaCha20, "chacha20");
 cipher::stream_cipher_seek_test!(chacha20_seek, ChaCha20);
 
-#[cfg(feature = "xchacha20")]
+#[cfg(feature = "xchacha")]
 #[rustfmt::skip]
 mod xchacha20 {
     use chacha20::{Key, XChaCha20, XNonce};


### PR DESCRIPTION
The rationale mostly comes from:
- ["Too Much Crypto" by Jean-Philippe Aumasson](https://eprint.iacr.org/2019/1492.pdf)
- The 7 round design of [Blake3](https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf)
- The 12 round design of [KangarooTwelve](https://keccak.team/kangarootwelve.html)
  - Slide "Status of Keccak & KangarooTwelve cryptanalysis" (page 33) of those [slides](https://keccak.team/files/K12atACNS.pdf)
  - The rationale in the [spec](https://keccak.team/files/KangarooTwelve.pdf)

There is probably some more doc to update to reflect the changes made to structures to make them more generic.
Also, it would probably make sense to rename the feature `xchacha20` to `xchacha`.

See also https://github.com/cryptocorrosion/cryptocorrosion/pull/42