### PR TITLE
ChaCha20: Fix stream-length overflow check

### DIFF
--- a/chacha20/src/chacha.rs
+++ b/chacha20/src/chacha.rs
@@ -184,11 +184,15 @@ impl<R: Rounds> StreamCipherSeek for ChaCha<R> {
 impl<R: Rounds> ChaCha<R> {
     /// Check data length
     fn check_data_len(&self, data: &[u8]) -> Result<(), LoopError> {
-        let byte_after_last = self.counter
-            .checked_mul(BLOCK_SIZE as u64).ok_or(LoopError)?
-            .checked_add(self.buffer_pos as u64).ok_or(LoopError)?
-            .checked_add(data.len() as u64).ok_or(LoopError)?;
-        if byte_after_last > ((MAX_BLOCKS+1)*BLOCK_SIZE) as u64 {
+        let byte_after_last = self
+            .counter
+            .checked_mul(BLOCK_SIZE as u64)
+            .ok_or(LoopError)?
+            .checked_add(self.buffer_pos as u64)
+            .ok_or(LoopError)?
+            .checked_add(data.len() as u64)
+            .ok_or(LoopError)?;
+        if byte_after_last > ((MAX_BLOCKS + 1) * BLOCK_SIZE) as u64 {
             Err(LoopError)
         } else {
             Ok(())

--- a/chacha20/src/chacha.rs
+++ b/chacha20/src/chacha.rs
@@ -192,7 +192,7 @@ impl<R: Rounds> ChaCha<R> {
             .ok_or(LoopError)?
             .checked_add(data.len() as u64)
             .ok_or(LoopError)?;
-        if byte_after_last > ((MAX_BLOCKS + 1) * BLOCK_SIZE) as u64 {
+        if byte_after_last > ((MAX_BLOCKS as u64) + 1) * (BLOCK_SIZE as u64) {
             Err(LoopError)
         } else {
             Ok(())

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -73,6 +73,7 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
+#![feature(untagged_unions)]
 
 mod backend;
 #[cfg(feature = "cipher")]

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -74,7 +74,6 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
-#![feature(untagged_unions)]
 
 mod backend;
 #[cfg(feature = "cipher")]

--- a/chacha20/tests/lib.rs
+++ b/chacha20/tests/lib.rs
@@ -9,88 +9,103 @@ cipher::stream_cipher_seek_test!(chacha20_seek, ChaCha20);
 mod overflow {
     use cipher::{NewCipher, StreamCipher, StreamCipherSeek};
 
-    const OFFSET_256GB: u64 = 256u64<<30;
+    const OFFSET_256GB: u64 = 256u64 << 30;
 
     #[test]
     fn bad_overflow_check1() {
-        let mut cipher = chacha20::ChaCha20::new(&Default::default(),
-            &Default::default());
-        cipher.try_seek(OFFSET_256GB-1).expect("Couldn't seek to nearly 256GB");
-        let mut data = [0u8;1];
-        cipher.try_apply_keystream(&mut data)
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(), &Default::default());
+        cipher
+            .try_seek(OFFSET_256GB - 1)
+            .expect("Couldn't seek to nearly 256GB");
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
             .expect("Couldn't encrypt the last byte of 256GB");
         assert_eq!(cipher.try_current_pos::<u64>().unwrap(), OFFSET_256GB);
-        let mut data = [0u8;1];
-        cipher.try_apply_keystream(&mut data)
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
             .expect_err("Could encrypt past the last byte of 256GB");
     }
 
     #[test]
     fn bad_overflow_check2() {
-        let mut cipher = chacha20::ChaCha20::new(&Default::default(),
-            &Default::default());
-        cipher.try_seek(OFFSET_256GB-1).expect("Couldn't seek to nearly 256GB");
-        let mut data = [0u8;2];
-        cipher.try_apply_keystream(&mut data)
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(), &Default::default());
+        cipher
+            .try_seek(OFFSET_256GB - 1)
+            .expect("Couldn't seek to nearly 256GB");
+        let mut data = [0u8; 2];
+        cipher
+            .try_apply_keystream(&mut data)
             .expect_err("Could encrypt over the 256GB boundary");
     }
 
     #[test]
     fn bad_overflow_check3() {
-        let mut cipher = chacha20::ChaCha20::new(&Default::default(),
-            &Default::default());
-        cipher.try_seek(OFFSET_256GB-1).expect("Couldn't seek to nearly 256GB");
-        let mut data = [0u8;1];
-        cipher.try_apply_keystream(&mut data)
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(), &Default::default());
+        cipher
+            .try_seek(OFFSET_256GB - 1)
+            .expect("Couldn't seek to nearly 256GB");
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
             .expect("Couldn't encrypt the last byte of 256GB");
         assert_eq!(cipher.try_current_pos::<u64>().unwrap(), OFFSET_256GB);
-        let mut data = [0u8;63];
-        cipher.try_apply_keystream(&mut data)
+        let mut data = [0u8; 63];
+        cipher
+            .try_apply_keystream(&mut data)
             .expect_err("Could encrypt past the last byte of 256GB");
     }
 
     #[test]
     fn bad_overflow_check4() {
-        let mut cipher = chacha20::ChaCha20::new(&Default::default(),
-            &Default::default());
-        cipher.try_seek(OFFSET_256GB-1).expect("Couldn't seek to nearly 256GB");
-        let mut data = [0u8;1];
-        cipher.try_apply_keystream(&mut data)
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(), &Default::default());
+        cipher
+            .try_seek(OFFSET_256GB - 1)
+            .expect("Couldn't seek to nearly 256GB");
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
             .expect("Couldn't encrypt the last byte of 256GB");
         assert_eq!(cipher.try_current_pos::<u64>().unwrap(), OFFSET_256GB);
-        let mut data = [0u8;64];
-        cipher.try_apply_keystream(&mut data)
+        let mut data = [0u8; 64];
+        cipher
+            .try_apply_keystream(&mut data)
             .expect_err("Could encrypt past the last byte of 256GB");
     }
 
     #[test]
     fn bad_overflow_check5() {
-        let mut cipher = chacha20::ChaCha20::new(&Default::default(),
-            &Default::default());
-        cipher.try_seek(OFFSET_256GB-1).expect("Couldn't seek to nearly 256GB");
-        let mut data = [0u8;1];
-        cipher.try_apply_keystream(&mut data)
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(), &Default::default());
+        cipher
+            .try_seek(OFFSET_256GB - 1)
+            .expect("Couldn't seek to nearly 256GB");
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
             .expect("Couldn't encrypt the last byte of 256GB");
         assert_eq!(cipher.try_current_pos::<u64>().unwrap(), OFFSET_256GB);
-        let mut data = [0u8;65];
-        cipher.try_apply_keystream(&mut data)
+        let mut data = [0u8; 65];
+        cipher
+            .try_apply_keystream(&mut data)
             .expect_err("Could encrypt past the last byte of 256GB");
     }
 
     #[test]
     fn bad_overflow_check6() {
-        let mut cipher = chacha20::ChaCha20::new(&Default::default(),
-            &Default::default());
-        cipher.try_seek(OFFSET_256GB).expect_err("Could seek to 256GB");
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(), &Default::default());
+        cipher
+            .try_seek(OFFSET_256GB)
+            .expect_err("Could seek to 256GB");
     }
 
     #[test]
     fn bad_overflow_check7() {
-        let mut cipher = chacha20::ChaCha20::new(&Default::default(),
-            &Default::default());
-        if let Ok(()) = cipher.try_seek(OFFSET_256GB+63) {
-            let mut data = [0u8;1];
-            cipher.try_apply_keystream(&mut data)
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(), &Default::default());
+        if let Ok(()) = cipher.try_seek(OFFSET_256GB + 63) {
+            let mut data = [0u8; 1];
+            cipher
+                .try_apply_keystream(&mut data)
                 .expect_err("Could encrypt the 64th byte past the 256GB boundary");
         }
     }

--- a/chacha20/tests/lib.rs
+++ b/chacha20/tests/lib.rs
@@ -6,6 +6,96 @@ use chacha20::ChaCha20;
 cipher::stream_cipher_test!(chacha20_core, ChaCha20, "chacha20");
 cipher::stream_cipher_seek_test!(chacha20_seek, ChaCha20);
 
+mod overflow {
+    use cipher::{NewCipher, StreamCipher, StreamCipherSeek};
+
+    const OFFSET_256GB: u64 = 256u64<<30;
+
+    #[test]
+    fn bad_overflow_check1() {
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(),
+            &Default::default());
+        cipher.try_seek(OFFSET_256GB-1).expect("Couldn't seek to nearly 256GB");
+        let mut data = [0u8;1];
+        cipher.try_apply_keystream(&mut data)
+            .expect("Couldn't encrypt the last byte of 256GB");
+        assert_eq!(cipher.try_current_pos::<u64>().unwrap(), OFFSET_256GB);
+        let mut data = [0u8;1];
+        cipher.try_apply_keystream(&mut data)
+            .expect_err("Could encrypt past the last byte of 256GB");
+    }
+
+    #[test]
+    fn bad_overflow_check2() {
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(),
+            &Default::default());
+        cipher.try_seek(OFFSET_256GB-1).expect("Couldn't seek to nearly 256GB");
+        let mut data = [0u8;2];
+        cipher.try_apply_keystream(&mut data)
+            .expect_err("Could encrypt over the 256GB boundary");
+    }
+
+    #[test]
+    fn bad_overflow_check3() {
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(),
+            &Default::default());
+        cipher.try_seek(OFFSET_256GB-1).expect("Couldn't seek to nearly 256GB");
+        let mut data = [0u8;1];
+        cipher.try_apply_keystream(&mut data)
+            .expect("Couldn't encrypt the last byte of 256GB");
+        assert_eq!(cipher.try_current_pos::<u64>().unwrap(), OFFSET_256GB);
+        let mut data = [0u8;63];
+        cipher.try_apply_keystream(&mut data)
+            .expect_err("Could encrypt past the last byte of 256GB");
+    }
+
+    #[test]
+    fn bad_overflow_check4() {
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(),
+            &Default::default());
+        cipher.try_seek(OFFSET_256GB-1).expect("Couldn't seek to nearly 256GB");
+        let mut data = [0u8;1];
+        cipher.try_apply_keystream(&mut data)
+            .expect("Couldn't encrypt the last byte of 256GB");
+        assert_eq!(cipher.try_current_pos::<u64>().unwrap(), OFFSET_256GB);
+        let mut data = [0u8;64];
+        cipher.try_apply_keystream(&mut data)
+            .expect_err("Could encrypt past the last byte of 256GB");
+    }
+
+    #[test]
+    fn bad_overflow_check5() {
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(),
+            &Default::default());
+        cipher.try_seek(OFFSET_256GB-1).expect("Couldn't seek to nearly 256GB");
+        let mut data = [0u8;1];
+        cipher.try_apply_keystream(&mut data)
+            .expect("Couldn't encrypt the last byte of 256GB");
+        assert_eq!(cipher.try_current_pos::<u64>().unwrap(), OFFSET_256GB);
+        let mut data = [0u8;65];
+        cipher.try_apply_keystream(&mut data)
+            .expect_err("Could encrypt past the last byte of 256GB");
+    }
+
+    #[test]
+    fn bad_overflow_check6() {
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(),
+            &Default::default());
+        cipher.try_seek(OFFSET_256GB).expect_err("Could seek to 256GB");
+    }
+
+    #[test]
+    fn bad_overflow_check7() {
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(),
+            &Default::default());
+        if let Ok(()) = cipher.try_seek(OFFSET_256GB+63) {
+            let mut data = [0u8;1];
+            cipher.try_apply_keystream(&mut data)
+                .expect_err("Could encrypt the 64th byte past the 256GB boundary");
+        }
+    }
+}
+
 #[cfg(feature = "xchacha20")]
 #[rustfmt::skip]
 mod xchacha20 {


### PR DESCRIPTION
It seems that the stream-length-overflow check has been through a few iterations, and at some point along the way it developed troublesome edge-case behavior. This adds 7 unit tests to exercise the behavior, a confusing subset of which (1,2,3,6,7) fail on the current upstream branch. it also adds a simplified stream-length-overflow check and enforces stream-position checking in `try_seek()`. Those changes make all the new tests pass.

Based on a quick glance through the history, I'm not sure when this problem appeared. It doesn't seem easy to exploit unless you're very deliberately extracting more keystream than you should be allowed to, but it definitely needs a fix.