### PR TITLE
chacha20: remove `Clone` impls on RNGs

### DIFF
--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -1,7 +1,9 @@
 //! Block RNG based on rand_core::BlockRng
 
-use rand_core::block::{BlockRng, BlockRngCore};
-use rand_core::{CryptoRng, Error, RngCore, SeedableRng};
+use rand_core::{
+    block::{BlockRng, BlockRngCore},
+    CryptoRng, Error, RngCore, SeedableRng,
+};
 
 use crate::{
     backend::{Core, BUFFER_SIZE},
@@ -13,7 +15,6 @@ use core::convert::TryInto;
 macro_rules! impl_chacha_rng {
     ($name:ident, $core:ident, $rounds:ident, $doc:expr) => {
         #[doc = $doc]
-        #[derive(Clone)]
         #[cfg_attr(docsrs, doc(cfg(feature = "rng")))]
         pub struct $name(BlockRng<$core>);
 
@@ -52,7 +53,6 @@ macro_rules! impl_chacha_rng {
         impl CryptoRng for $name {}
 
         #[doc = "Core random number generator, for use with [`rand_core::block::BlockRng`]"]
-        #[derive(Clone)]
         #[cfg_attr(docsrs, doc(cfg(feature = "rng")))]
         pub struct $core {
             block: Core<$rounds>,


### PR DESCRIPTION
Removes `derive(Clone)` on `ChaCha*Rng*`.

They date back to the original PR which added RNG support (#63).

Allowing `Clone` on an RNG is problematic because the cloned RNG will have the same internal state, duplicating outputs which can be catastrophic in a cryptographic context.

Instead, the `SeedableRng::from_rng` method can be used to "fork" one RNG from another, seeing a new RNG with an output from another:

https://docs.rs/rand_core/0.6.2/rand_core/trait.SeedableRng.html#method.from_rng