### PR TITLE
cipher v0.3.0-pre.5

### DIFF
--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "0.3.0-pre.4"
+cipher = "0.3.0-pre.5"
 
 [dev-dependencies]
 aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
-cipher = { version = "0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "0.3.0-pre.5", features = ["dev"] }
 hex-literal = "0.2"

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre.4"
+cipher = "=0.3.0-pre.5"
 
 [dev-dependencies]
 aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "=0.3.0-pre.5", features = ["dev"] }
 hex-literal = "0.2"

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2018"
 
 [dependencies]
 cfg-if = "1"
-cipher = { version = "=0.3.0-pre.4", optional = true }
+cipher = { version = "=0.3.0-pre.5", optional = true }
 rand_core = { version = "0.6", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
@@ -26,7 +26,7 @@ zeroize = { version = "1", optional = true, default-features = false }
 cpuid-bool = "0.2"
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "=0.3.0-pre.5", features = ["dev"] }
 hex-literal = "0.2"
 
 [features]

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre.4"
+cipher = "=0.3.0-pre.5"
 
 [dev-dependencies]
 aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "=0.3.0-pre.5", features = ["dev"] }
 hex-literal = "0.2"

--- a/hc-256/Cargo.toml
+++ b/hc-256/Cargo.toml
@@ -11,5 +11,5 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre.4"
+cipher = "=0.3.0-pre.5"
 zeroize = { version = "1", optional = true, default-features = false }

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre.4"
+cipher = "=0.3.0-pre.5"
 
 [dev-dependencies]
 aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "=0.3.0-pre.5", features = ["dev"] }
 hex-literal = "0.2"

--- a/rabbit/Cargo.toml
+++ b/rabbit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rabbit"
 description = "An implementation of the Rabbit Stream Cipher Algorithm"
-version = "0.3.0-pre.4"
+version = "0.3.0-pre.5"
 authors = ["AIkorsky <aikorsky@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RustCrypto/stream-ciphers"
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre.4"
+cipher = "=0.3.0-pre.5"
 zeroize = { version = "1", optional = true, default-features = false, features = ["zeroize_derive"] }
 
 [features]

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cipher = "=0.3.0-pre.4"
+cipher = "=0.3.0-pre.5"
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-cipher = { version = "=0.3.0-pre.4", features = ["dev"] }
+cipher = { version = "=0.3.0-pre.5", features = ["dev"] }
 
 [features]
 default = ["xsalsa20"]


### PR DESCRIPTION
Due to a cyclical dependency between `aes` and `ctr`, this is expected to fail CI, and can only be fixed by a new `aes` crate release.