### PR TITLE
ctr v0.7.0-pre.4

### DIFF
--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctr"
-version = "0.7.0-pre.3"
+version = "0.7.0-pre.4"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "CTR block mode of operation"


### PR DESCRIPTION
Due to a cyclical dependency between `aes` and `ctr`, this is expected to fail CI, and can only be fixed by a new `ctr` crate release.