### PR TITLE
ctr v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,8 @@
 [[package]]
 name = "aes"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#db3763260d02187f841ee57a51a83ce60045013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89fe2093c8636691cd8ad25555898ec057ca42fbfd79f3630ac3ae6c040533"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -72,7 +73,7 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "ctr"
-version = "0.7.0-pre.4"
+version = "0.7.0"
 dependencies = [
  "aes",
  "cipher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,3 @@ members = [
     "rabbit",
     "salsa20",
 ]
-
-[patch.crates-io]
-aes = { git = "https://github.com/RustCrypto/block-ciphers.git" }

--- a/ctr/CHANGELOG.md
+++ b/ctr/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2020-04-29)
+### Changed
+- Generic implementation of CTR ([#195])
+- Removed `Ctr32LE` mask bit ([#197])
+- Bump `cipher` crate dependency to v0.3 ([#226])
+
+[#195]: https://github.com/RustCrypto/stream-ciphers/pull/195
+[#197]: https://github.com/RustCrypto/stream-ciphers/pull/197
+[#226]: https://github.com/RustCrypto/stream-ciphers/pull/226
+
 ## 0.6.0 (2020-10-16)
 ### Added
 - `Ctr32BE` and `Ctr32LE` ([#170])

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctr"
-version = "0.7.0-pre.4"
+version = "0.7.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "CTR block mode of operation"


### PR DESCRIPTION
### Changed
- Generic implementation of CTR ([#195])
- Removed `Ctr32LE` mask bit ([#197])
- Bump `cipher` crate dependency to v0.3 ([#226])

[#195]: https://github.com/RustCrypto/stream-ciphers/pull/195
[#197]: https://github.com/RustCrypto/stream-ciphers/pull/197
[#226]: https://github.com/RustCrypto/stream-ciphers/pull/226