### PR TITLE
chacha20 v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/chacha20/CHANGELOG.md
+++ b/chacha20/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2021-04-29)
+### Added
+- AVX2 detection; MSRV 1.49+ ([#200], [#212])
+- `XChaCha8` and `XChaCha12` ([#215])
+
+### Changed
+- Full 64-bit counters ([#217])
+- Bump `cipher` crate dependency to v0.3 release ([#226])
+
+### Fixed
+- `rng` feature on big endian platforms ([#202])
+- Stream-length overflow check ([#216])
+
+### Removed
+- `Clone` impls on RNGs ([#220])
+
+[#200]: https://github.com/RustCrypto/stream-ciphers/pull/200
+[#202]: https://github.com/RustCrypto/stream-ciphers/pull/202
+[#212]: https://github.com/RustCrypto/stream-ciphers/pull/212
+[#215]: https://github.com/RustCrypto/stream-ciphers/pull/215
+[#216]: https://github.com/RustCrypto/stream-ciphers/pull/216
+[#217]: https://github.com/RustCrypto/stream-ciphers/pull/217
+[#220]: https://github.com/RustCrypto/stream-ciphers/pull/220
+[#226]: https://github.com/RustCrypto/stream-ciphers/pull/226
+
 ## 0.6.0 (2020-10-16)
 ### Changed
 - Rename `Cipher` to `ChaCha` ([#177])

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.7.0-pre"
+version = "0.7.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
### Added
- AVX2 detection; MSRV 1.49+ ([#200], [#212])
- `XChaCha8` and `XChaCha12` ([#215])

### Changed
- Full 64-bit counters ([#217])
- Bump `cipher` crate dependency to v0.3 release ([#226])

### Fixed
- `rng` feature on big endian platforms ([#202])
- Stream-length overflow check ([#216])

### Removed
- `Clone` impls on RNGs ([#220])

[#200]: https://github.com/RustCrypto/stream-ciphers/pull/200
[#202]: https://github.com/RustCrypto/stream-ciphers/pull/202
[#212]: https://github.com/RustCrypto/stream-ciphers/pull/212
[#215]: https://github.com/RustCrypto/stream-ciphers/pull/215
[#216]: https://github.com/RustCrypto/stream-ciphers/pull/216
[#217]: https://github.com/RustCrypto/stream-ciphers/pull/217
[#220]: https://github.com/RustCrypto/stream-ciphers/pull/220
[#226]: https://github.com/RustCrypto/stream-ciphers/pull/226