### PR TITLE
chacha20: add `hchacha` feature

### DIFF
--- a/.github/workflows/chacha20.yml
+++ b/.github/workflows/chacha20.yml
@@ -39,6 +39,7 @@ jobs:
           override: true
           profile: minimal
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features cipher
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features hchacha
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features legacy
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features rng
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features xchacha

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -33,6 +33,7 @@ hex-literal = "0.2"
 default = ["xchacha"]
 expose-core = []
 force-soft = []
+hchacha = ["xchacha"]
 legacy = ["cipher"]
 rng = ["rand_core"]
 std = ["cipher/std"]

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -99,6 +99,9 @@ pub use crate::{
     rounds::{R12, R20, R8},
 };
 
+#[cfg(feature = "hchacha")]
+pub use crate::xchacha::hchacha;
+
 #[cfg(feature = "legacy")]
 pub use crate::legacy::{ChaCha20Legacy, LegacyNonce};
 

--- a/chacha20/src/xchacha.rs
+++ b/chacha20/src/xchacha.rs
@@ -94,16 +94,17 @@ impl<R: Rounds> StreamCipherSeek for XChaCha<R> {
 ///
 /// HChaCha takes 512-bits of input:
 ///
-/// * Constants (`u32` x 4)
-/// * Key (`u32` x 8)
-/// * Nonce (`u32` x 4)
+/// - Constants: `u32` x 4
+/// - Key: `u32` x 8
+/// - Nonce: `u32` x 4
 ///
 /// It produces 256-bits of output suitable for use as a ChaCha key
 ///
 /// For more information on HSalsa on which HChaCha is based, see:
 ///
 /// <http://cr.yp.to/snuffle/xsalsa-20110204.pdf>
-fn hchacha<R: Rounds>(key: &Key, input: &GenericArray<u8, U16>) -> GenericArray<u8, U32> {
+#[cfg_attr(docsrs, doc(cfg(feature = "hchacha")))]
+pub fn hchacha<R: Rounds>(key: &Key, input: &GenericArray<u8, U16>) -> GenericArray<u8, U32> {
     let mut state = [0u32; 16];
     state[..4].copy_from_slice(&CONSTANTS);
 


### PR DESCRIPTION
Adds a feature for exposing the `hchacha` function, which is useful for a ChaCha-based `crypto_box`.