### PR TITLE
chacha20 v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/chacha20/CHANGELOG.md
+++ b/chacha20/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.7.0 (2021-04-29)
+## 0.7.1 (2021-04-29)
+### Added
+- `hchacha` feature ([#234])
+
+[#234]: https://github.com/RustCrypto/stream-ciphers/pull/234
+
+## 0.7.0 (2021-04-29) [YANKED]
 ### Added
 - AVX2 detection; MSRV 1.49+ ([#200], [#212])
 - `XChaCha8` and `XChaCha12` ([#215])

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
### Added
- `hchacha` feature ([#234])

[#234]: https://github.com/RustCrypto/stream-ciphers/pull/234
