### PR TITLE
export `XChaCha`

### DIFF
--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -111,7 +111,7 @@ pub use rng::{
 };
 
 #[cfg(feature = "xchacha")]
-pub use self::xchacha::{XChaCha12, XChaCha20, XChaCha8, XNonce};
+pub use self::xchacha::{XChaCha, XChaCha12, XChaCha20, XChaCha8, XNonce};
 
 /// Size of a ChaCha20 block in bytes
 pub const BLOCK_SIZE: usize = 64;

--- a/chacha20/src/xchacha.rs
+++ b/chacha20/src/xchacha.rs
@@ -54,6 +54,13 @@ pub type XChaCha12 = XChaCha<R12>;
 #[cfg_attr(docsrs, doc(cfg(feature = "xchacha")))]
 pub type XChaCha8 = XChaCha<R8>;
 
+/// XChaCha family stream cipher, generic around a number of rounds.
+///
+/// Use the [`XChaCha8`], [`XChaCha12`], or [`XChaCha20`] type aliases to select
+/// a specific number of rounds.
+///
+/// Generally [`XChaCha20`] is preferred.
+#[cfg_attr(docsrs, doc(cfg(feature = "xchacha")))]
 pub struct XChaCha<R: Rounds>(ChaCha<R, C64>);
 
 impl<R: Rounds> NewCipher for XChaCha<R> {


### PR DESCRIPTION
When looking at the documentation in v0.6 it was possible to see what traits `XChaCha20` implement.
In v0.7 this is no longer possible since `XChaCha` is private and `XChaCha20` is only a type alias.

To fix this, I'm proposing to export `XChaCha`.