### PR TITLE
`chacha20`: Improve AVX2 performance

### DIFF
--- a/chacha20/src/backend/avx2.rs
+++ b/chacha20/src/backend/avx2.rs
@@ -181,22 +181,74 @@ unsafe fn double_quarter_round(a: &mut __m256i, b: &mut __m256i, c: &mut __m256i
     cols_to_rows(a, b, c, d);
 }
 
+/// The goal of this function is to transform the state words from:
+/// ```text
+/// [a0, a1, a2, a3]    [ 0,  1,  2,  3]
+/// [b0, b1, b2, b3] == [ 4,  5,  6,  7]
+/// [c0, c1, c2, c3]    [ 8,  9, 10, 11]
+/// [d0, d1, d2, d3]    [12, 13, 14, 15]
+/// ```
+///
+/// to:
+/// ```text
+/// [a0, a1, a2, a3]    [ 0,  1,  2,  3]
+/// [b1, b2, b3, b0] == [ 5,  6,  7,  4]
+/// [c2, c3, c0, c1]    [10, 11,  8,  9]
+/// [d3, d0, d1, d2]    [15, 12, 13, 14]
+/// ```
+///
+/// so that we can apply [`add_xor_rot`] to the resulting columns, and have it compute the
+/// "diagonal rounds" (as defined in RFC 7539) in parallel. In practice, this shuffle is
+/// non-optimal: the last state word to be altered in `add_xor_rot` is `b`, so the shuffle
+/// blocks on the result of `b` being calculated.
+///
+/// We can optimize this by observing that the four quarter rounds in `add_xor_rot` are
+/// data-independent: they only access a single column of the state, and thus the order of
+/// the columns does not matter. We therefore instead shuffle the other three state words,
+/// to obtain the following equivalent layout:
+/// ```text
+/// [a3, a0, a1, a2]    [ 3,  0,  1,  2]
+/// [b0, b1, b2, b3] == [ 4,  5,  6,  7]
+/// [c1, c2, c3, c0]    [ 9, 10, 11,  8]
+/// [d2, d3, d0, d1]    [14, 15, 12, 13]
+/// ```
+///
+/// See https://github.com/sneves/blake2-avx2/pull/4 for additional details. The earliest
+/// known occurrence of this optimization is in floodyberry's SSE4 ChaCha code from 2014:
+/// - https://github.com/floodyberry/chacha-opt/blob/0ab65cb99f5016633b652edebaf3691ceb4ff753/chacha_blocks_ssse3-64.S#L639-L643
 #[inline]
 #[target_feature(enable = "avx2")]
-unsafe fn rows_to_cols(_a: &mut __m256i, b: &mut __m256i, c: &mut __m256i, d: &mut __m256i) {
-    // b = ROR256_B(b); c = ROR256_C(c); d = ROR256_D(d);
-    *b = _mm256_shuffle_epi32(*b, 0b_00_11_10_01); // _MM_SHUFFLE(0, 3, 2, 1)
-    *c = _mm256_shuffle_epi32(*c, 0b_01_00_11_10); // _MM_SHUFFLE(1, 0, 3, 2)
-    *d = _mm256_shuffle_epi32(*d, 0b_10_01_00_11); // _MM_SHUFFLE(2, 1, 0, 3)
+unsafe fn rows_to_cols(a: &mut __m256i, _b: &mut __m256i, c: &mut __m256i, d: &mut __m256i) {
+    // c = ROR256_B(c); d = ROR256_C(d); a = ROR256_D(a);
+    *c = _mm256_shuffle_epi32(*c, 0b_00_11_10_01); // _MM_SHUFFLE(0, 3, 2, 1)
+    *d = _mm256_shuffle_epi32(*d, 0b_01_00_11_10); // _MM_SHUFFLE(1, 0, 3, 2)
+    *a = _mm256_shuffle_epi32(*a, 0b_10_01_00_11); // _MM_SHUFFLE(2, 1, 0, 3)
 }
 
+/// The goal of this function is to transform the state words from:
+/// ```text
+/// [a3, a0, a1, a2]    [ 3,  0,  1,  2]
+/// [b0, b1, b2, b3] == [ 4,  5,  6,  7]
+/// [c1, c2, c3, c0]    [ 9, 10, 11,  8]
+/// [d2, d3, d0, d1]    [14, 15, 12, 13]
+/// ```
+///
+/// to:
+/// ```text
+/// [a0, a1, a2, a3]    [ 0,  1,  2,  3]
+/// [b0, b1, b2, b3] == [ 4,  5,  6,  7]
+/// [c0, c1, c2, c3]    [ 8,  9, 10, 11]
+/// [d0, d1, d2, d3]    [12, 13, 14, 15]
+/// ```
+///
+/// reversing the transformation of [`rows_to_cols`].
 #[inline]
 #[target_feature(enable = "avx2")]
-unsafe fn cols_to_rows(_a: &mut __m256i, b: &mut __m256i, c: &mut __m256i, d: &mut __m256i) {
-    // b = ROR256_D(b); c = ROR256_C(c); d = ROR256_B(d);
-    *b = _mm256_shuffle_epi32(*b, 0b_10_01_00_11); // _MM_SHUFFLE(2, 1, 0, 3)
-    *c = _mm256_shuffle_epi32(*c, 0b_01_00_11_10); // _MM_SHUFFLE(1, 0, 3, 2)
-    *d = _mm256_shuffle_epi32(*d, 0b_00_11_10_01); // _MM_SHUFFLE(0, 3, 2, 1)
+unsafe fn cols_to_rows(a: &mut __m256i, _b: &mut __m256i, c: &mut __m256i, d: &mut __m256i) {
+    // c = ROR256_D(c); d = ROR256_C(d); a = ROR256_B(a);
+    *c = _mm256_shuffle_epi32(*c, 0b_10_01_00_11); // _MM_SHUFFLE(2, 1, 0, 3)
+    *d = _mm256_shuffle_epi32(*d, 0b_01_00_11_10); // _MM_SHUFFLE(1, 0, 3, 2)
+    *a = _mm256_shuffle_epi32(*a, 0b_00_11_10_01); // _MM_SHUFFLE(0, 3, 2, 1)
 }
 
 #[inline]

--- a/chacha20/src/backend/sse2.rs
+++ b/chacha20/src/backend/sse2.rs
@@ -133,58 +133,53 @@ unsafe fn store(v0: __m128i, v1: __m128i, v2: __m128i, v3: __m128i, output: &mut
 
 #[inline]
 #[target_feature(enable = "sse2")]
-unsafe fn double_quarter_round(
-    v0: &mut __m128i,
-    v1: &mut __m128i,
-    v2: &mut __m128i,
-    v3: &mut __m128i,
-) {
-    add_xor_rot(v0, v1, v2, v3);
-    rows_to_cols(v0, v1, v2, v3);
-    add_xor_rot(v0, v1, v2, v3);
-    cols_to_rows(v0, v1, v2, v3);
+unsafe fn double_quarter_round(a: &mut __m128i, b: &mut __m128i, c: &mut __m128i, d: &mut __m128i) {
+    add_xor_rot(a, b, c, d);
+    rows_to_cols(a, b, c, d);
+    add_xor_rot(a, b, c, d);
+    cols_to_rows(a, b, c, d);
 }
 
 #[inline]
 #[target_feature(enable = "sse2")]
-unsafe fn rows_to_cols(_v0: &mut __m128i, v1: &mut __m128i, v2: &mut __m128i, v3: &mut __m128i) {
-    // v1 >>>= 32; v2 >>>= 64; v3 >>>= 96;
-    *v1 = _mm_shuffle_epi32(*v1, 0b_00_11_10_01); // _MM_SHUFFLE(0, 3, 2, 1)
-    *v2 = _mm_shuffle_epi32(*v2, 0b_01_00_11_10); // _MM_SHUFFLE(1, 0, 3, 2)
-    *v3 = _mm_shuffle_epi32(*v3, 0b_10_01_00_11); // _MM_SHUFFLE(2, 1, 0, 3)
+unsafe fn rows_to_cols(_a: &mut __m128i, b: &mut __m128i, c: &mut __m128i, d: &mut __m128i) {
+    // b >>>= 32; c >>>= 64; d >>>= 96;
+    *b = _mm_shuffle_epi32(*b, 0b_00_11_10_01); // _MM_SHUFFLE(0, 3, 2, 1)
+    *c = _mm_shuffle_epi32(*c, 0b_01_00_11_10); // _MM_SHUFFLE(1, 0, 3, 2)
+    *d = _mm_shuffle_epi32(*d, 0b_10_01_00_11); // _MM_SHUFFLE(2, 1, 0, 3)
 }
 
 #[inline]
 #[target_feature(enable = "sse2")]
-unsafe fn cols_to_rows(_v0: &mut __m128i, v1: &mut __m128i, v2: &mut __m128i, v3: &mut __m128i) {
-    // v1 <<<= 32; v2 <<<= 64; v3 <<<= 96;
-    *v1 = _mm_shuffle_epi32(*v1, 0b_10_01_00_11); // _MM_SHUFFLE(2, 1, 0, 3)
-    *v2 = _mm_shuffle_epi32(*v2, 0b_01_00_11_10); // _MM_SHUFFLE(1, 0, 3, 2)
-    *v3 = _mm_shuffle_epi32(*v3, 0b_00_11_10_01); // _MM_SHUFFLE(0, 3, 2, 1)
+unsafe fn cols_to_rows(_a: &mut __m128i, b: &mut __m128i, c: &mut __m128i, d: &mut __m128i) {
+    // b <<<= 32; c <<<= 64; d <<<= 96;
+    *b = _mm_shuffle_epi32(*b, 0b_10_01_00_11); // _MM_SHUFFLE(2, 1, 0, 3)
+    *c = _mm_shuffle_epi32(*c, 0b_01_00_11_10); // _MM_SHUFFLE(1, 0, 3, 2)
+    *d = _mm_shuffle_epi32(*d, 0b_00_11_10_01); // _MM_SHUFFLE(0, 3, 2, 1)
 }
 
 #[inline]
 #[target_feature(enable = "sse2")]
-unsafe fn add_xor_rot(v0: &mut __m128i, v1: &mut __m128i, v2: &mut __m128i, v3: &mut __m128i) {
-    // v0 += v1; v3 ^= v0; v3 <<<= (16, 16, 16, 16);
-    *v0 = _mm_add_epi32(*v0, *v1);
-    *v3 = _mm_xor_si128(*v3, *v0);
-    *v3 = _mm_xor_si128(_mm_slli_epi32(*v3, 16), _mm_srli_epi32(*v3, 16));
+unsafe fn add_xor_rot(a: &mut __m128i, b: &mut __m128i, c: &mut __m128i, d: &mut __m128i) {
+    // a += b; d ^= a; d <<<= (16, 16, 16, 16);
+    *a = _mm_add_epi32(*a, *b);
+    *d = _mm_xor_si128(*d, *a);
+    *d = _mm_xor_si128(_mm_slli_epi32(*d, 16), _mm_srli_epi32(*d, 16));
 
-    // v2 += v3; v1 ^= v2; v1 <<<= (12, 12, 12, 12);
-    *v2 = _mm_add_epi32(*v2, *v3);
-    *v1 = _mm_xor_si128(*v1, *v2);
-    *v1 = _mm_xor_si128(_mm_slli_epi32(*v1, 12), _mm_srli_epi32(*v1, 20));
+    // c += d; b ^= c; b <<<= (12, 12, 12, 12);
+    *c = _mm_add_epi32(*c, *d);
+    *b = _mm_xor_si128(*b, *c);
+    *b = _mm_xor_si128(_mm_slli_epi32(*b, 12), _mm_srli_epi32(*b, 20));
 
-    // v0 += v1; v3 ^= v0; v3 <<<= (8, 8, 8, 8);
-    *v0 = _mm_add_epi32(*v0, *v1);
-    *v3 = _mm_xor_si128(*v3, *v0);
-    *v3 = _mm_xor_si128(_mm_slli_epi32(*v3, 8), _mm_srli_epi32(*v3, 24));
+    // a += b; d ^= a; d <<<= (8, 8, 8, 8);
+    *a = _mm_add_epi32(*a, *b);
+    *d = _mm_xor_si128(*d, *a);
+    *d = _mm_xor_si128(_mm_slli_epi32(*d, 8), _mm_srli_epi32(*d, 24));
 
-    // v2 += v3; v1 ^= v2; v1 <<<= (7, 7, 7, 7);
-    *v2 = _mm_add_epi32(*v2, *v3);
-    *v1 = _mm_xor_si128(*v1, *v2);
-    *v1 = _mm_xor_si128(_mm_slli_epi32(*v1, 7), _mm_srli_epi32(*v1, 25));
+    // c += d; b ^= c; b <<<= (7, 7, 7, 7);
+    *c = _mm_add_epi32(*c, *d);
+    *b = _mm_xor_si128(*b, *c);
+    *b = _mm_xor_si128(_mm_slli_epi32(*b, 7), _mm_srli_epi32(*b, 25));
 }
 
 #[cfg(all(test, target_feature = "sse2"))]

--- a/chacha20/src/backend/sse2.rs
+++ b/chacha20/src/backend/sse2.rs
@@ -140,22 +140,74 @@ unsafe fn double_quarter_round(a: &mut __m128i, b: &mut __m128i, c: &mut __m128i
     cols_to_rows(a, b, c, d);
 }
 
+/// The goal of this function is to transform the state words from:
+/// ```text
+/// [a0, a1, a2, a3]    [ 0,  1,  2,  3]
+/// [b0, b1, b2, b3] == [ 4,  5,  6,  7]
+/// [c0, c1, c2, c3]    [ 8,  9, 10, 11]
+/// [d0, d1, d2, d3]    [12, 13, 14, 15]
+/// ```
+///
+/// to:
+/// ```text
+/// [a0, a1, a2, a3]    [ 0,  1,  2,  3]
+/// [b1, b2, b3, b0] == [ 5,  6,  7,  4]
+/// [c2, c3, c0, c1]    [10, 11,  8,  9]
+/// [d3, d0, d1, d2]    [15, 12, 13, 14]
+/// ```
+///
+/// so that we can apply [`add_xor_rot`] to the resulting columns, and have it compute the
+/// "diagonal rounds" (as defined in RFC 7539) in parallel. In practice, this shuffle is
+/// non-optimal: the last state word to be altered in `add_xor_rot` is `b`, so the shuffle
+/// blocks on the result of `b` being calculated.
+///
+/// We can optimize this by observing that the four quarter rounds in `add_xor_rot` are
+/// data-independent: they only access a single column of the state, and thus the order of
+/// the columns does not matter. We therefore instead shuffle the other three state words,
+/// to obtain the following equivalent layout:
+/// ```text
+/// [a3, a0, a1, a2]    [ 3,  0,  1,  2]
+/// [b0, b1, b2, b3] == [ 4,  5,  6,  7]
+/// [c1, c2, c3, c0]    [ 9, 10, 11,  8]
+/// [d2, d3, d0, d1]    [14, 15, 12, 13]
+/// ```
+///
+/// See https://github.com/sneves/blake2-avx2/pull/4 for additional details. The earliest
+/// known occurrence of this optimization is in floodyberry's SSE4 ChaCha code from 2014:
+/// - https://github.com/floodyberry/chacha-opt/blob/0ab65cb99f5016633b652edebaf3691ceb4ff753/chacha_blocks_ssse3-64.S#L639-L643
 #[inline]
 #[target_feature(enable = "sse2")]
-unsafe fn rows_to_cols(_a: &mut __m128i, b: &mut __m128i, c: &mut __m128i, d: &mut __m128i) {
-    // b >>>= 32; c >>>= 64; d >>>= 96;
-    *b = _mm_shuffle_epi32(*b, 0b_00_11_10_01); // _MM_SHUFFLE(0, 3, 2, 1)
-    *c = _mm_shuffle_epi32(*c, 0b_01_00_11_10); // _MM_SHUFFLE(1, 0, 3, 2)
-    *d = _mm_shuffle_epi32(*d, 0b_10_01_00_11); // _MM_SHUFFLE(2, 1, 0, 3)
+unsafe fn rows_to_cols(a: &mut __m128i, _b: &mut __m128i, c: &mut __m128i, d: &mut __m128i) {
+    // c >>>= 32; d >>>= 64; a >>>= 96;
+    *c = _mm_shuffle_epi32(*c, 0b_00_11_10_01); // _MM_SHUFFLE(0, 3, 2, 1)
+    *d = _mm_shuffle_epi32(*d, 0b_01_00_11_10); // _MM_SHUFFLE(1, 0, 3, 2)
+    *a = _mm_shuffle_epi32(*a, 0b_10_01_00_11); // _MM_SHUFFLE(2, 1, 0, 3)
 }
 
+/// The goal of this function is to transform the state words from:
+/// ```text
+/// [a3, a0, a1, a2]    [ 3,  0,  1,  2]
+/// [b0, b1, b2, b3] == [ 4,  5,  6,  7]
+/// [c1, c2, c3, c0]    [ 9, 10, 11,  8]
+/// [d2, d3, d0, d1]    [14, 15, 12, 13]
+/// ```
+///
+/// to:
+/// ```text
+/// [a0, a1, a2, a3]    [ 0,  1,  2,  3]
+/// [b0, b1, b2, b3] == [ 4,  5,  6,  7]
+/// [c0, c1, c2, c3]    [ 8,  9, 10, 11]
+/// [d0, d1, d2, d3]    [12, 13, 14, 15]
+/// ```
+///
+/// reversing the transformation of [`rows_to_cols`].
 #[inline]
 #[target_feature(enable = "sse2")]
-unsafe fn cols_to_rows(_a: &mut __m128i, b: &mut __m128i, c: &mut __m128i, d: &mut __m128i) {
-    // b <<<= 32; c <<<= 64; d <<<= 96;
-    *b = _mm_shuffle_epi32(*b, 0b_10_01_00_11); // _MM_SHUFFLE(2, 1, 0, 3)
-    *c = _mm_shuffle_epi32(*c, 0b_01_00_11_10); // _MM_SHUFFLE(1, 0, 3, 2)
-    *d = _mm_shuffle_epi32(*d, 0b_00_11_10_01); // _MM_SHUFFLE(0, 3, 2, 1)
+unsafe fn cols_to_rows(a: &mut __m128i, _b: &mut __m128i, c: &mut __m128i, d: &mut __m128i) {
+    // c <<<= 32; d <<<= 64; a <<<= 96;
+    *c = _mm_shuffle_epi32(*c, 0b_10_01_00_11); // _MM_SHUFFLE(2, 1, 0, 3)
+    *d = _mm_shuffle_epi32(*d, 0b_01_00_11_10); // _MM_SHUFFLE(1, 0, 3, 2)
+    *a = _mm_shuffle_epi32(*a, 0b_00_11_10_01); // _MM_SHUFFLE(0, 3, 2, 1)
 }
 
 #[inline]


### PR DESCRIPTION
- A bunch of instructions for accessing the 128-bit lanes have been replaced by a union.
- I've implemented a widely-used ChaCha optimisation (that I spotted in `c2-chacha`).