### PR TITLE
chacha20 v0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/chacha20/CHANGELOG.md
+++ b/chacha20/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.3 (2021-08-27)
+### Changed
+- Improve AVX2 performance ([#261])
+- Bump `cpufeatures` to v0.2 ([#265])
+
+[#261]: https://github.com/RustCrypto/stream-ciphers/pull/261
+[#265]: https://github.com/RustCrypto/stream-ciphers/pull/265
+
 ## 0.7.2 (2021-07-20)
 ### Changed
 - Pin `zeroize` dependency to v1.3 ([#256])

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.7.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.7.3" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -20,7 +20,7 @@ edition = "2018"
 cfg-if = "1"
 cipher = { version = "0.3", optional = true }
 rand_core = { version = "0.6", optional = true, default-features = false }
-zeroize = { version = "=1.3", optional = true, default-features = false }
+zeroize = { version = ">=1, <1.4", optional = true, default-features = false }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2"

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -71,7 +71,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/chacha20/0.7.2"
+    html_root_url = "https://docs.rs/chacha20/0.7.3"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]

--- a/chacha20/src/max_blocks.rs
+++ b/chacha20/src/max_blocks.rs
@@ -11,7 +11,7 @@ pub trait MaxCounter: Copy {
 pub struct C32;
 
 impl MaxCounter for C32 {
-    const MAX_BLOCKS: Option<u64> = Some(core::u32::MAX as u64);
+    const MAX_BLOCKS: Option<u64> = Some(u32::MAX as u64);
 }
 
 /// 64-bit counter


### PR DESCRIPTION
### Changed
- Improve AVX2 performance ([#261])
- Bump `cpufeatures` to v0.2 ([#265])

[#261]: https://github.com/RustCrypto/stream-ciphers/pull/261
[#265]: https://github.com/RustCrypto/stream-ciphers/pull/265