### PR TITLE
`chacha20`: Process 4 blocks at a time in AVX2 backend

### DIFF
--- a/.github/workflows/chacha20.yml
+++ b/.github/workflows/chacha20.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.49.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -53,7 +53,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.49.0 # MSRV
+            rust: 1.51.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -61,7 +61,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.49.0 # MSRV
+            rust: 1.51.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -90,7 +90,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.49.0 # MSRV
+            rust: 1.51.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -98,7 +98,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.49.0 # MSRV
+            rust: 1.51.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -126,7 +126,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.49.0 # MSRV
+            rust: 1.51.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -134,7 +134,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.49.0 # MSRV
+            rust: 1.51.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -160,13 +160,13 @@ jobs:
         include:
           # ARM64
           - target: aarch64-unknown-linux-gnu
-            rust: 1.49.0 # MSRV
+            rust: 1.51.0 # MSRV
           - target: aarch64-unknown-linux-gnu
             rust: stable
 
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.49.0 # MSRV
+            rust: 1.51.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
 

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.49.0 # MSRV (highest in repo)
+          toolchain: 1.51.0 # MSRV (highest in repo)
           components: clippy
           override: true
           profile: minimal

--- a/chacha20/README.md
+++ b/chacha20/README.md
@@ -62,7 +62,7 @@ stream cipher itself) are designed to execute in constant time.
 
 ## Minimum Supported Rust Version
 
-Rust **1.49** or higher.
+Rust **1.51** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -94,7 +94,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/chacha20/badge.svg
 [docs-link]: https://docs.rs/chacha20/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260049-stream-ciphers
 [build-image]: https://github.com/RustCrypto/stream-ciphers/workflows/chacha20/badge.svg?branch=master&event=push

--- a/chacha20/src/backend/autodetect.rs
+++ b/chacha20/src/backend/autodetect.rs
@@ -8,7 +8,9 @@ use core::mem::ManuallyDrop;
 
 /// Size of buffers passed to `generate` and `apply_keystream` for this
 /// backend, which operates on two blocks in parallel for optimal performance.
-pub(crate) const BUFFER_SIZE: usize = BLOCK_SIZE * 2;
+/// The backend consumes four blocks at a time, so that the AVX2 implementation
+/// can additionally pipeline the pairs of blocks for better ILP.
+pub(crate) const BUFFER_SIZE: usize = BLOCK_SIZE * 4;
 
 cpufeatures::new!(avx2_cpuid, "avx2");
 

--- a/ctr/src/lib.rs
+++ b/ctr/src/lib.rs
@@ -43,6 +43,7 @@
     html_root_url = "https://docs.rs/ctr/0.8.0"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
+#![allow(clippy::upper_case_acronyms)]
 
 pub use cipher;
 use cipher::{


### PR DESCRIPTION
We switch to a 4-block buffer for the combined SSE2 / AVX2 backend, which allows the AVX2 backend to process them together, while the SSE2 backend continues to process one block at a time.

The AVX2 backend is refactored to enable interleaving the instructions per pair of blocks, for better ILP.

Closes #262.