### PR TITLE
chacha20: lock to `zeroize` <1.5

### DIFF
--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2018"
 cfg-if = "1"
 cipher = { version = "0.3", optional = true }
 rand_core = { version = "0.6", optional = true, default-features = false }
-zeroize = { version = ">=1, <1.4", optional = true, default-features = false }
+zeroize = { version = ">=1, <1.5", optional = true, default-features = false }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2"


### PR DESCRIPTION
Now that MSRV is 1.51+, this allows use of `zeroize` 1.4.