### PR TITLE
chacha20 v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ received any formal cryptographic and security reviews/audits.
 |--------------|-----------|---------------|------|
 | [`cfb-mode`] | [![crates.io](https://img.shields.io/crates/v/cfb-mode.svg)](https://crates.io/crates/cfb-mode) | [![Documentation](https://docs.rs/cfb-mode/badge.svg)](https://docs.rs/cfb-mode) | 1.41 |
 | [`cfb8`]     | [![crates.io](https://img.shields.io/crates/v/cfb8.svg)](https://crates.io/crates/cfb8) | [![Documentation](https://docs.rs/cfb8/badge.svg)](https://docs.rs/cfb8) | 1.41 |
-| [`chacha20`] | [![crates.io](https://img.shields.io/crates/v/chacha20.svg)](https://crates.io/crates/chacha20) | [![Documentation](https://docs.rs/chacha20/badge.svg)](https://docs.rs/chacha20) | 1.41 |
+| [`chacha20`] | [![crates.io](https://img.shields.io/crates/v/chacha20.svg)](https://crates.io/crates/chacha20) | [![Documentation](https://docs.rs/chacha20/badge.svg)](https://docs.rs/chacha20) | 1.51 |
 | [`ctr`]      | [![crates.io](https://img.shields.io/crates/v/ctr.svg)](https://crates.io/crates/ctr) | [![Documentation](https://docs.rs/ctr/badge.svg)](https://docs.rs/ctr) | 1.41 |
 | [`hc-256`]   | [![crates.io](https://img.shields.io/crates/v/hc-256.svg)](https://crates.io/crates/hc-256) | [![Documentation](https://docs.rs/hc-256/badge.svg)](https://docs.rs/hc-256) | 1.41 |
 | [`ofb`]      | [![crates.io](https://img.shields.io/crates/v/ofb.svg)](https://crates.io/crates/ofb) | [![Documentation](https://docs.rs/ofb/badge.svg)](https://docs.rs/ofb) | 1.41 |

--- a/chacha20/CHANGELOG.md
+++ b/chacha20/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2021-08-29)
+### Added
+- SSE2 autodetection support ([#270])
+
+### Changed
+- AVX2 performance improvements ([#267], [#267])
+- MSRV 1.51+ ([#267])
+- Lock to `zeroize` <1.5 ([#269])
+
+### Removed
+- `xchacha` feature: all `XChaCha*` types are now available by-default ([#271])
+
+[#267]: https://github.com/RustCrypto/stream-ciphers/pull/267
+[#269]: https://github.com/RustCrypto/stream-ciphers/pull/269
+[#270]: https://github.com/RustCrypto/stream-ciphers/pull/270
+[#271]: https://github.com/RustCrypto/stream-ciphers/pull/271
+
 ## 0.7.3 (2021-08-27)
 ### Changed
 - Improve AVX2 performance ([#261])

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.7.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.8.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -74,7 +74,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/chacha20/0.7.3"
+    html_root_url = "https://docs.rs/chacha20/0.8.0"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]


### PR DESCRIPTION
### Added
- SSE2 autodetection support ([#270])

### Changed
- AVX2 performance improvements ([#267], [#267])
- MSRV 1.51+ ([#267])
- Lock to `zeroize` <1.5 ([#269])

### Removed
- `xchacha` feature: all `XChaCha*` types are now available by-default ([#271])

[#267]: https://github.com/RustCrypto/stream-ciphers/pull/267
[#269]: https://github.com/RustCrypto/stream-ciphers/pull/269
[#270]: https://github.com/RustCrypto/stream-ciphers/pull/270
[#271]: https://github.com/RustCrypto/stream-ciphers/pull/271