### PR TITLE
Add HC-128 and Fix HC-256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "hc-256"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "cipher",
  "zeroize",

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ received any formal cryptographic and security reviews/audits.
 | [`cfb8`]     | [![crates.io](https://img.shields.io/crates/v/cfb8.svg)](https://crates.io/crates/cfb8) | [![Documentation](https://docs.rs/cfb8/badge.svg)](https://docs.rs/cfb8) | 1.41 |
 | [`chacha20`] | [![crates.io](https://img.shields.io/crates/v/chacha20.svg)](https://crates.io/crates/chacha20) | [![Documentation](https://docs.rs/chacha20/badge.svg)](https://docs.rs/chacha20) | 1.51 |
 | [`ctr`]      | [![crates.io](https://img.shields.io/crates/v/ctr.svg)](https://crates.io/crates/ctr) | [![Documentation](https://docs.rs/ctr/badge.svg)](https://docs.rs/ctr) | 1.41 |
+| [`hc-128`]   | [![crates.io](https://img.shields.io/crates/v/hc-128.svg)](https://crates.io/crates/hc-128) | [![Documentation](https://docs.rs/hc-128/badge.svg)](https://docs.rs/hc-256) | 1.58 |
 | [`hc-256`]   | [![crates.io](https://img.shields.io/crates/v/hc-256.svg)](https://crates.io/crates/hc-256) | [![Documentation](https://docs.rs/hc-256/badge.svg)](https://docs.rs/hc-256) | 1.41 |
 | [`ofb`]      | [![crates.io](https://img.shields.io/crates/v/ofb.svg)](https://crates.io/crates/ofb) | [![Documentation](https://docs.rs/ofb/badge.svg)](https://docs.rs/ofb) | 1.41 |
 | [`rabbit`]  | [![crates.io](https://img.shields.io/crates/v/rabbit.svg)](https://crates.io/crates/rabbit) | [![Documentation](https://docs.rs/rabbit/badge.svg)](https://docs.rs/rabbit) | 1.41 |
@@ -104,6 +105,7 @@ dual licensed as above, without any additional terms or conditions.
 [`cfb8`]: https://github.com/RustCrypto/stream-ciphers/tree/master/cfb8
 [`chacha20`]: https://github.com/RustCrypto/stream-ciphers/tree/master/chacha20
 [`ctr`]: https://github.com/RustCrypto/stream-ciphers/tree/master/ctr
+[`hc-128`]: https://github.com/RustCrypto/stream-ciphers/tree/master/hc-128
 [`hc-256`]: https://github.com/RustCrypto/stream-ciphers/tree/master/hc-256
 [`ofb`]: https://github.com/RustCrypto/stream-ciphers/tree/master/ofb
 [`rabbit`]: https://github.com/RustCrypto/stream-ciphers/tree/master/rabbit

--- a/hc-128/Cargo.toml
+++ b/hc-128/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "hc-128"
+version = "0.1.0"
+authors = ["Quentin K"]
+license = "MIT OR Apache-2.0"
+description = "HC-128 Stream Cipher"
+repository = "https://github.com/RustCrypto/stream-ciphers"
+keywords = ["crypto", "stream-cipher", "trait"]
+categories = ["cryptography", "no-std"]
+readme = "README.md"
+edition = "2018"
+
+[dependencies]
+cipher = "0.3"
+zeroize = { version = "=1.3", optional = true, default-features = false }

--- a/hc-128/LICENSE-APACHE
+++ b/hc-128/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/hc-128/LICENSE-MIT
+++ b/hc-128/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2018 Eric McCorkle
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/hc-128/src/lib.rs
+++ b/hc-128/src/lib.rs
@@ -1,0 +1,163 @@
+//! HC 128 Stream Cipher
+
+#![no_std]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_root_url = "https://docs.rs/hc-128/0.1.0"
+)]
+#![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
+
+pub use cipher;
+
+pub use cipher;
+
+use cipher::{
+    consts::U32, errors::LoopError, generic_array::GenericArray, NewCipher, StreamCipher,
+};
+
+#[cfg(cargo_feature = "zeroize")]
+use std::ops::Drop;
+#[cfg(cargo_feature = "zeroize")]
+use zeroize::Zeroize;
+
+const TABLE_SIZE: usize = 512;
+const TABLE_MASK: usize = TABLE_SIZE - 1;
+const INIT_SIZE: usize = 1280;
+const BITS: usize = 128;
+const WORDS: usize = 128 / 32;
+
+/// HC 256 Stream Cipher
+pub struct Hc128 {
+    p_table: [u32; TABLE_SIZE],
+    q_table: [u32; TABLE_SIZE],
+    word: u32,
+    idx: u32,
+    offset: u8,
+}
+
+impl NewCipher for Hc128 {
+    /// Key size in bytes
+    type KeySize = U16;
+    /// Nonce size in bytes
+    type NonceSize = U16;
+
+    fn new(key: &GenericArray<u8, Self::KeySize>, iv: &GenericArray<u8, Self::NonceSize>) -> Self {
+        let mut out = Hc128::create();
+        out.init(key.as_slice(), iv.as_slice());
+        out
+    }
+}
+
+impl Hc128 {
+    fn create() -> Hc128 {
+        Hc128 {
+            p_table: [0; TABLE_SIZE],
+            q_table: [0; TABLE_SIZE],
+            word: 0,
+            idx: 0,
+            offset: 0,
+        }
+    }
+
+    fn init(&mut self, key: &[u8], iv: &[u8]) {
+        let mut w_table = [0; INIT_SIZE];
+
+        for i in 0..WORDS {
+            w_table[i] = key[i * 4] as u32
+                | ((key[(i * 4) + 1] as u32) << 8)
+                | ((key[(i * 4) + 2] as u32) << 16)
+                | ((key[(i * 4) + 3] as u32) << 24);
+            w_table[i + WORDS] = w_table[i];
+
+            w_table[i + (WORDS * 2)] = iv[i * 4] as u32
+                | ((iv[(i * 4) + 1] as u32) << 8)
+                | ((iv[(i * 4) + 2] as u32) << 16)
+                | ((iv[(i * 4) + 3] as u32) << 24);
+            w_table[i + (WORDS * 3)] = w_table[i + (WORDS * 2)];
+        }
+
+        self.p_table[..TABLE_SIZE].clone_from_slice(&w_table[256..(TABLE_SIZE + 256)]);
+        self.q_table[..TABLE_SIZE].clone_from_slice(&w_table[768..(TABLE_SIZE + 768)]);
+
+        self.idx = 0;
+
+        #[cfg(cargo_feature = "zeroize")]
+        w_table.zeroize();
+
+        for i in 0..1024 {
+            if i < 512 {
+                self.p_table[i] = self.gen_word()
+            } else {
+                self.q_table[i] = self.gen_word()
+            }
+        }
+    }
+
+    fn gen_word(&mut self) -> u32 {
+        let i = self.idx as usize;
+        let j = self.idx as usize & TABLE_MASK;
+
+        self.offset = 0;
+        self.idx = (self.idx + 1) & (1023);
+
+        if i < 512 {
+            self.p_table[j] = self.p_table[j].wrapping_add(self.g1(self.p_table[(j.wrapping_sub(3)) & 255], self.p_table[(j.wrapping_sub(10)) & 255], self.p_table[(j.wrapping_sub(511)) & 255]));
+            self.h1(self.p_table[j.wrapping_sub(12)]) ^ self.p_table[j]
+        } else {
+            self.q_table[j] = self.q_table[j].wrapping_add(self.g2(self.q_table[(j.wrapping_sub(3)) & 255], self.q_table[(j.wrapping_sub(10)) & 255], self.q_table[(j.wrapping_sub(511)) & 255]));
+            self.h2(self.q_table[j.wrapping_sub(12)]) ^ self.q_table[j]
+        }
+    }
+
+    #[inline]
+    fn g1(&self, x: u32, y: u32, z: u32) -> u32 {
+        (x.rotate_right(10) ^ z.rotate_right(23)).wrapping_add(y.rotate_right(8))
+    }
+
+    #[inline]
+    fn g2(&self, x: u32, y: u32, z: u32) -> u32 {
+        (x.rotate_left(10) ^ z.rotate_left(23)).wrapping_add(y.rotate_left(8))
+    }
+
+    #[inline]
+    fn h1(&self, x: u32) -> u32 {
+        self.q_table[(x & 0xff) as usize]
+            .wrapping_add(self.q_table[(256 + ((x >> 8) & 0xff)) as usize])
+    }
+
+    #[inline]
+    fn h2(&self, x: u32) -> u32 {
+        self.p_table[(x & 0xff) as usize]
+            .wrapping_add(self.p_table[(256 + ((x >> 8) & 0xff)) as usize])
+    }
+}
+
+#[cfg(cargo_feature = "zeroize")]
+impl Zeroize for Hc128 {
+    fn zeroize(&mut self) {
+        self.p_table.zeroize();
+        self.q_table.zeroize();
+        self.word.zeroize();
+        self.idx.zeroize();
+        self.offset.zeroize();
+    }
+}
+
+#[cfg(cargo_feature = "zeroize")]
+impl Droself.p_tablef(o.wrapping_sub(c128)  & 255{)
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+#[inline]
+fn f1(x: u32) -> u32 {
+    x.rotate_right(7) ^ x.rotate_right(18) ^ (x >> 3)
+}
+
+#[inline]
+fn f2(x: u32) -> u32 {
+    x.rotate_right(17) ^ x.rotate_right(19) ^ (x >> 10)
+}

--- a/hc-256/Cargo.toml
+++ b/hc-256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hc-256"
-version = "0.4.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["Eric McCorkle <eric@metricspace.net>"]
 license = "MIT OR Apache-2.0"
 description = "HC-256 Stream Cipher"

--- a/hc-256/src/lib.rs
+++ b/hc-256/src/lib.rs
@@ -4,7 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/hc-256/0.4.1"
+    html_root_url = "https://docs.rs/hc-256/0.5.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
@@ -135,9 +135,9 @@ impl Hc256 {
     #[inline]
     fn h2(&self, x: u32) -> u32 {
         self.qtable[(x & 0xff) as usize]
-            .wrapping_add(self.qtable[(256 + ((x >> 8) & 0xff)) as usize])
-            .wrapping_add(self.qtable[(512 + ((x >> 16) & 0xff)) as usize])
-            .wrapping_add(self.qtable[(768 + ((x >> 24) & 0xff)) as usize])
+            .wrapping_add(self.ptable[(256 + ((x >> 8) & 0xff)) as usize])
+            .wrapping_add(self.ptable[(512 + ((x >> 16) & 0xff)) as usize])
+            .wrapping_add(self.ptable[(768 + ((x >> 24) & 0xff)) as usize])
     }
 
     fn gen_word(&mut self) -> u32 {

--- a/hc-256/src/lib.rs
+++ b/hc-256/src/lib.rs
@@ -22,7 +22,7 @@ use zeroize::Zeroize;
 
 const TABLE_SIZE: usize = 1024;
 const TABLE_MASK: usize = TABLE_SIZE - 1;
-const INIT_SIZE: usize = 2660;
+const INIT_SIZE: usize = 2560;
 const KEY_BITS: usize = 256;
 const KEY_WORDS: usize = KEY_BITS / 32;
 const IV_BITS: usize = 256;
@@ -134,7 +134,7 @@ impl Hc256 {
 
     #[inline]
     fn h2(&self, x: u32) -> u32 {
-        self.qtable[(x & 0xff) as usize]
+        self.ptable[(x & 0xff) as usize]
             .wrapping_add(self.ptable[(256 + ((x >> 8) & 0xff)) as usize])
             .wrapping_add(self.ptable[(512 + ((x >> 16) & 0xff)) as usize])
             .wrapping_add(self.ptable[(768 + ((x >> 24) & 0xff)) as usize])


### PR DESCRIPTION
 #219 This implementation of HC-128 does not yet have the test vectors. HC-256 was using a table size of 2660 instead of 2560, this does not cause issue with the generated key stream, but slightly lengthens the initialization time. The function `h2` in HC-256 used `self.ptable` instead of `self.qtable`, this means that it does not apply linear masking when the stream is using `h2`. For inputs that never get output from `h2` it gives the correct results, but once `h2` is in use the values are incorrect.