### PR TITLE
chacha20: add v0.8.2 release notes

### DIFF
--- a/chacha20/CHANGELOG.md
+++ b/chacha20/CHANGELOG.md
@@ -23,6 +23,12 @@ configuration flags ([#293])
 [#290]: https://github.com/RustCrypto/stream-ciphers/pull/290
 [#293]: https://github.com/RustCrypto/stream-ciphers/pull/293
 
+## 0.8.2 (2022-07-07)
+### Changed
+- Unpin `zeroize` dependency ([#301])
+
+[#301]: https://github.com/RustCrypto/stream-ciphers/pull/301
+
 ## 0.8.1 (2021-08-30)
 ### Added
 - NEON implementation for aarch64 ([#274])


### PR DESCRIPTION
This commit contains release notes for the v0.8.2 release of `chacha20`, which backports unpinning `zeroize`, allowing it to build with newer releases of `zeroize`.

The original motivation for pinning it was to preserve MSRV, however this has proven to be extremely problematic in that it prevents what would otherwise be compatible versions of crates from working together.

Users who wish to support lower MSRV should explicitly pin `zeroize` to `<1.5` themselves.