### PR TITLE
chacha20: add `chacha20_force_neon` cfg attribute

### DIFF
--- a/.github/workflows/chacha20.yml
+++ b/.github/workflows/chacha20.yml
@@ -189,7 +189,7 @@ jobs:
           # ARM64 with NEON backend
           - target: aarch64-unknown-linux-gnu
             rust: stable
-            features: --features neon
+            rustflags: --cfg chacha20_force_neon
 
           # PPC32
           - target: powerpc-unknown-linux-gnu
@@ -210,12 +210,5 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
-      - name: Install precompiled cross
-        run: |
-          export URL=$(curl -s https://api.github.com/repos/cross-rs/cross/releases/latest | \
-            jq -r '.assets[] | select(.name | contains("x86_64-unknown-linux-gnu.tar.gz")) | .browser_download_url')
-          wget -O /tmp/binaries.tar.gz $URL
-          tar -C /tmp -xzf /tmp/binaries.tar.gz
-          mv /tmp/cross ~/.cargo/bin
-        shell: bash
-      - run: cross test --package chacha20 --target ${{ matrix.target }} ${{ matrix.features }}
+      - uses: RustCrypto/actions/cross-install@master
+      - run: RUSTFLAGS="${{ matrix.rustflags }}" cross test --package chacha20 --target ${{ matrix.target }}

--- a/chacha20/src/backends.rs
+++ b/chacha20/src/backends.rs
@@ -15,7 +15,7 @@ cfg_if! {
                 pub(crate) mod sse2;
             }
         }
-    } else if #[cfg(all(feature = "neon", target_arch = "aarch64", target_feature = "neon"))] {
+    } else if #[cfg(all(chacha20_force_neon, target_arch = "aarch64", target_feature = "neon"))] {
         pub(crate) mod neon;
     } else {
         pub(crate) mod soft;

--- a/chacha20/src/backends/neon.rs
+++ b/chacha20/src/backends/neon.rs
@@ -1,13 +1,14 @@
-//! NEON-optimized implementation for aarch64 CPUs adapted from the Crypto++ `chacha_simd`
-//! implementation by Jack Lloyd and Jeffrey Walton (public domain).
+//! NEON-optimized implementation for aarch64 CPUs.
+//!
+//! Adapted from the Crypto++ `chacha_simd` implementation by Jack Lloyd and
+//! Jeffrey Walton (public domain).
+
 use crate::{Block, StreamClosure, Unsigned, STATE_WORDS};
 use cipher::{
     consts::{U4, U64},
     BlockSizeUser, ParBlocks, ParBlocksSizeUser, StreamBackend,
 };
-use core::marker::PhantomData;
-
-use core::arch::aarch64::*;
+use core::{arch::aarch64::*, marker::PhantomData};
 
 #[inline]
 #[target_feature(enable = "neon")]

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -83,11 +83,13 @@
 //!
 //! You can modify crate using the following configuration flags:
 //!
+//! - `chacha20_force_avx2`: force AVX2 backend on x86/x86_64 targets.
+//!   Requires enabled AVX2 target feature. Ignored on non-x86(-64) targets.
+//! - `chacha20_force_neon`: force NEON backend on ARM targets.
+//!   Requires enabled NEON target feature. Ignored on non-ARM targets. Nightly-only.
 //! - `chacha20_force_soft`: force software backend.
-//! - `chacha20_force_sse2`: force SSE2 backend. Requires enabled SSE2 target feature,
-//! ignored on non-x86(-64) targets.
-//! - `chacha20_force_avx2`: force AVX2 backend. Requires enabled AVX2 target feature,
-//! ignored on non-x86(-64) targets.
+//! - `chacha20_force_sse2`: force SSE2 backend on x86/x86_64 targets.
+//!   Requires enabled SSE2 target feature. Ignored on non-x86(-64) targets.
 //!
 //! The flags can be enabled using `RUSTFLAGS` environmental variable
 //! (e.g. `RUSTFLAGS="--cfg chacha20_force_avx2"`) or by modifying `.cargo/config`.
@@ -278,7 +280,7 @@ impl<R: Unsigned> StreamCipherCore for ChaChaCore<R> {
                         }
                     }
                 }
-            } else if #[cfg(all(feature = "neon", target_arch = "aarch64", target_feature = "neon"))] {
+            } else if #[cfg(all(chacha20_force_neon, target_arch = "aarch64", target_feature = "neon"))] {
                 unsafe {
                     backends::neon::inner::<R, _>(&mut self.state, f);
                 }


### PR DESCRIPTION
Adds an attribute consistent with the other target-specific cfg attributes for enabling the NEON backend.

This unblocks releasing NEON support as a feature.