### PR TITLE
chacha20 v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/chacha20/CHANGELOG.md
+++ b/chacha20/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.9.0 (2021-02-21)
+## 0.9.1 (2023-04-01)
+### Added
+- NEON support via `chacha20_force_neon` cfg attribute ([#310], [#317])
+
+[#310]: https://github.com/RustCrypto/stream-ciphers/pull/310
+[#317]: https://github.com/RustCrypto/stream-ciphers/pull/317
+
+## 0.9.0 (2022-02-21)
 ### Added
 - `chacha20_force_soft`, `chacha20_force_sse2`, and `chacha20_force_avx2`
 configuration flags ([#293])

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.9.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.9.1"
 description = """
 The ChaCha20 stream cipher (RFC 8439) implemented in pure Rust using traits
 from the RustCrypto `cipher` crate, with optional architecture-specific
@@ -32,7 +32,6 @@ hex-literal = "0.3.3"
 [features]
 std = ["cipher/std"]
 zeroize = ["cipher/zeroize"]
-neon = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/chacha20/LICENSE-MIT
+++ b/chacha20/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2019-2022 The RustCrypto Project Developers
+Copyright (c) 2019-2023 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -104,11 +104,10 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/chacha20/0.9.0"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
-#![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
 #![allow(clippy::needless_range_loop)]
+#![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
 
 pub use cipher;
 


### PR DESCRIPTION
### Added
- NEON support via `chacha20_force_neon` cfg attribute ([#310], [#317])

[#310]: https://github.com/RustCrypto/stream-ciphers/pull/310
[#317]: https://github.com/RustCrypto/stream-ciphers/pull/317
