### PR TITLE
hc-256: use `ptable` instead of `qtable` in `h2` function

### DIFF
--- a/hc-256/src/lib.rs
+++ b/hc-256/src/lib.rs
@@ -198,10 +198,10 @@ impl Hc256Core {
 
     #[inline]
     fn h2(&self, x: u32) -> u32 {
-        self.qtable[(x & 0xff) as usize]
-            .wrapping_add(self.qtable[(256 + ((x >> 8) & 0xff)) as usize])
-            .wrapping_add(self.qtable[(512 + ((x >> 16) & 0xff)) as usize])
-            .wrapping_add(self.qtable[(768 + ((x >> 24) & 0xff)) as usize])
+        self.ptable[(x & 0xff) as usize]
+            .wrapping_add(self.ptable[(256 + ((x >> 8) & 0xff)) as usize])
+            .wrapping_add(self.ptable[(512 + ((x >> 16) & 0xff)) as usize])
+            .wrapping_add(self.ptable[(768 + ((x >> 24) & 0xff)) as usize])
     }
 
     fn gen_word(&mut self) -> u32 {


### PR DESCRIPTION
Fixing a small bug in the HC-256 stream cipher to use **ptable** instead of **qtable** for the **h2** function. The code properly decrypts up to 0x1000 bytes, but it fails to decrypt data that comes afterward due to this bug.

Data encrypted by the original code can still be fully decrypted despite its length, but will fail to be decrypted by other HC-256 libraries.   