### PR TITLE
Update all `hex-literal` to `0.4.1` and silence `clippy` warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "hex-literal"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "inout"

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -27,7 +27,7 @@ cpufeatures = "0.2"
 
 [dev-dependencies]
 cipher = { version = "0.4.4", features = ["dev"] }
-hex-literal = "0.3.3"
+hex-literal = "0.4.1"
 
 [features]
 std = ["cipher/std"]

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -231,6 +231,7 @@ impl<R: Unsigned> KeyIvInit for ChaChaCore<R> {
                     }
                 }
             } else {
+                #[allow(clippy::let_unit_value)]
                 let tokens = ();
             }
         }

--- a/hc-256/Cargo.toml
+++ b/hc-256/Cargo.toml
@@ -17,7 +17,7 @@ cipher = "0.4.4"
 
 [dev-dependencies]
 cipher = { version = "0.4.4", features = ["dev"] }
-hex-literal = "0.3.3"
+hex-literal = "0.4.1"
 
 [features]
 std = ["cipher/std"]

--- a/rabbit/Cargo.toml
+++ b/rabbit/Cargo.toml
@@ -17,7 +17,7 @@ cipher = "0.4.4"
 
 [dev-dependencies]
 cipher = { version = "0.4.4", features = ["dev"] }
-hex-literal = "0.3.3"
+hex-literal = "0.4.1"
 
 [features]
 std = ["cipher/std"]

--- a/rc4/Cargo.toml
+++ b/rc4/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 cipher = "0.4.4"
 
 [dev-dependencies]
-hex-literal = "0.3"
+hex-literal = "0.4.1"
 
 [features]
 std = ["cipher/std"]

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -17,7 +17,7 @@ cipher = "0.4.4"
 
 [dev-dependencies]
 cipher = { version = "0.4.4", features = ["dev"] }
-hex-literal = "0.3.3"
+hex-literal = "0.4.1"
 
 [features]
 std = ["cipher/std"]


### PR DESCRIPTION
This PR bumps all crates up to `hex-literal v0.4.1` - I opted for that over `0.4` as they're all `dev-dependencies` and shouldn't break anything for users downstream.

I also silenced a `clippy` warning in the `chacha20` crate. I tried to resolve it via moving the let bindings but apparently that was considered unstable, so silencing the warning was the next best option. 