### PR TITLE
Implement Clone for core structs.

### DIFF
--- a/chacha20/src/legacy.rs
+++ b/chacha20/src/legacy.rs
@@ -22,6 +22,7 @@ pub type LegacyNonce = GenericArray<u8, U8>;
 pub type ChaCha20Legacy = StreamCipherCoreWrapper<ChaCha20LegacyCore>;
 
 /// The ChaCha20 stream cipher (legacy "djb" construction with 64-bit nonce).
+#[derive(Clone)]
 pub struct ChaCha20LegacyCore(ChaChaCore<U10>);
 
 impl KeySizeUser for ChaCha20LegacyCore {

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -181,6 +181,7 @@ cfg_if! {
 }
 
 /// The ChaCha core function.
+#[derive(Clone)]
 pub struct ChaChaCore<R: Unsigned> {
     /// Internal state of the core function
     state: [u32; STATE_WORDS],

--- a/chacha20/src/xchacha.rs
+++ b/chacha20/src/xchacha.rs
@@ -36,6 +36,7 @@ pub type XChaCha12 = StreamCipherCoreWrapper<XChaChaCore<U6>>;
 pub type XChaCha8 = StreamCipherCoreWrapper<XChaChaCore<U4>>;
 
 /// The XChaCha core function.
+#[derive(Clone)]
 pub struct XChaChaCore<R: Unsigned>(ChaChaCore<R>);
 
 impl<R: Unsigned> KeySizeUser for XChaChaCore<R> {

--- a/hc-256/src/lib.rs
+++ b/hc-256/src/lib.rs
@@ -82,6 +82,7 @@ const IV_WORDS: usize = IV_BITS / 32;
 pub type Hc256 = StreamCipherCoreWrapper<Hc256Core>;
 
 /// The HC-256 stream cipher core
+#[derive(Clone)]
 pub struct Hc256Core {
     ptable: [u32; TABLE_SIZE],
     qtable: [u32; TABLE_SIZE],

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -118,6 +118,7 @@ const STATE_WORDS: usize = 16;
 const CONSTANTS: [u32; 4] = [0x6170_7865, 0x3320_646e, 0x7962_2d32, 0x6b20_6574];
 
 /// The Salsa20 core function.
+#[derive(Clone)]
 pub struct SalsaCore<R: Unsigned> {
     /// Internal state of the core function
     state: [u32; STATE_WORDS],

--- a/salsa20/src/xsalsa.rs
+++ b/salsa20/src/xsalsa.rs
@@ -23,6 +23,7 @@ pub type XSalsa12 = StreamCipherCoreWrapper<XSalsaCore<U6>>;
 pub type XSalsa8 = StreamCipherCoreWrapper<XSalsaCore<U4>>;
 
 /// The XSalsa core function.
+#[derive(Clone)]
 pub struct XSalsaCore<R: Unsigned>(SalsaCore<R>);
 
 impl<R: Unsigned> KeySizeUser for XSalsaCore<R> {


### PR DESCRIPTION
I'm trying to update `crypto_box` in our [tox](https://github.com/tox-rs/tox) crate. In the `0.8` version  `SalsaBox` used to have `Clone` implementation but not anymore in `0.9`. I guess it was just forgotten so I add `Clone` here for all new core structs.