### PR TITLE
Bump `cipher` to v0.5.0-pre.1; MSRV 1.65

### DIFF
--- a/.github/workflows/chacha20.yml
+++ b/.github/workflows/chacha20.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -53,7 +53,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -61,7 +61,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -86,7 +86,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -94,7 +94,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -119,7 +119,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -127,7 +127,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -152,7 +152,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -160,7 +160,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
     steps:
@@ -182,7 +182,7 @@ jobs:
         include:
           # ARM64
           - target: aarch64-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
           - target: aarch64-unknown-linux-gnu
             rust: stable
 
@@ -193,7 +193,7 @@ jobs:
 
           # PPC32
           - target: powerpc-unknown-linux-gnu
-            rust: 1.56.0 # MSRV
+            rust: 1.65.0 # MSRV
           - target: powerpc-unknown-linux-gnu
             rust: stable
 

--- a/.github/workflows/hc-256.yml
+++ b/.github/workflows/hc-256.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rabbit.yml
+++ b/.github/workflows/rabbit.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rc4.yml
+++ b/.github/workflows/rc4.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/salsa20.yml
+++ b/.github/workflows/salsa20.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,11 +11,11 @@ checksum = "847495c209977a90e8aad588b959d0ca9f5dc228096d29a6bd3defd53f35eaec"
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "d07a359e2b51a0e9b9d6a6d4582b7b62723e4a25f4e5ca6be70a6a00050202ab"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -26,7 +26,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.9.1"
+version = "0.10.0-pre"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "15e338a2ceb7493b9b89d12728c6feb2d4b61708cb63b577c556c92f43aef0cd"
 dependencies = [
  "blobby",
  "crypto-common",
@@ -57,27 +57,29 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "cc17eb697364b18256ec92675ebe6b7b153d2f1041e568d74533c5d0fc1ca162"
 dependencies = [
- "generic-array",
- "typenum",
+ "getrandom",
+ "hybrid-array",
+ "rand_core",
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
+name = "getrandom"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
- "typenum",
- "version_check",
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
 name = "hc-256"
-version = "0.5.0"
+version = "0.6.0-pre"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -85,18 +87,27 @@ dependencies = [
 
 [[package]]
 name = "hex-literal"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27fbaf242418fe980caf09ed348d5a6aeabe71fc1bd8bebad641f4591ae0a46d"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.2.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "96ea9986e1fde8d177cd039f00f9f316d3bfce9ebc2787c1267d4414adf3acb3"
 dependencies = [
  "block-padding",
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -107,15 +118,24 @@ checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "rabbit"
-version = "0.4.1"
+version = "0.5.0-pre"
 dependencies = [
  "cipher",
  "hex-literal",
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "rc4"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
  "cipher",
  "hex-literal",
@@ -123,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "salsa20"
-version = "0.10.2"
+version = "0.11.0-pre"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -137,13 +157,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
-name = "version_check"
-version = "0.9.4"
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "chacha20",
     "hc-256",

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ received any formal cryptographic and security reviews/audits.
 ## Crates
 | Name     | Crate name | Crates.io | Docs | MSRV | Security |
 |----------|------------|-----------|------|------|----------|
-| [ChaCha] | [`chacha20`] | [![crates.io](https://img.shields.io/crates/v/chacha20.svg)](https://crates.io/crates/chacha20) | [![Documentation](https://docs.rs/chacha20/badge.svg)](https://docs.rs/chacha20) | ![MSRV 1.56][msrv-1.56] | 💚 |
-| [HC-256] | [`hc-256`]   | [![crates.io](https://img.shields.io/crates/v/hc-256.svg)](https://crates.io/crates/hc-256) | [![Documentation](https://docs.rs/hc-256/badge.svg)](https://docs.rs/hc-256) | ![MSRV 1.56][msrv-1.56] | [💛](https://link.springer.com/chapter/10.1007/978-3-642-04846-3_4) |
-| [Rabbit] | [`rabbit`]  | [![crates.io](https://img.shields.io/crates/v/rabbit.svg)](https://crates.io/crates/rabbit) | [![Documentation](https://docs.rs/rabbit/badge.svg)](https://docs.rs/rabbit) | ![MSRV 1.56][msrv-1.56] | [💛](https://eprint.iacr.org/2013/780.pdf) |
-| [RC4]    | [`rc4`]  | [![crates.io](https://img.shields.io/crates/v/rc4.svg)](https://crates.io/crates/rc4) | [![Documentation](https://docs.rs/rc4/badge.svg)](https://docs.rs/rc4) | ![MSRV 1.56][msrv-1.56] | [💔](https://www.usenix.org/system/files/conference/usenixsecurity13/sec13-paper_alfardan.pdf) |
-| [Salsa20] | [`salsa20`]  | [![crates.io](https://img.shields.io/crates/v/salsa20.svg)](https://crates.io/crates/salsa20) | [![Documentation](https://docs.rs/salsa20/badge.svg)](https://docs.rs/salsa20) | ![MSRV 1.56][msrv-1.56] | 💚 |
+| [ChaCha] | [`chacha20`] | [![crates.io](https://img.shields.io/crates/v/chacha20.svg)](https://crates.io/crates/chacha20) | [![Documentation](https://docs.rs/chacha20/badge.svg)](https://docs.rs/chacha20) | ![MSRV 1.65][msrv-1.65] | 💚 |
+| [HC-256] | [`hc-256`]   | [![crates.io](https://img.shields.io/crates/v/hc-256.svg)](https://crates.io/crates/hc-256) | [![Documentation](https://docs.rs/hc-256/badge.svg)](https://docs.rs/hc-256) | ![MSRV 1.65][msrv-1.65] | [💛](https://link.springer.com/chapter/10.1007/978-3-642-04846-3_4) |
+| [Rabbit] | [`rabbit`]  | [![crates.io](https://img.shields.io/crates/v/rabbit.svg)](https://crates.io/crates/rabbit) | [![Documentation](https://docs.rs/rabbit/badge.svg)](https://docs.rs/rabbit) | ![MSRV 1.65][msrv-1.65] | [💛](https://eprint.iacr.org/2013/780.pdf) |
+| [RC4]    | [`rc4`]  | [![crates.io](https://img.shields.io/crates/v/rc4.svg)](https://crates.io/crates/rc4) | [![Documentation](https://docs.rs/rc4/badge.svg)](https://docs.rs/rc4) | ![MSRV 1.65][msrv-1.65] | [💔](https://www.usenix.org/system/files/conference/usenixsecurity13/sec13-paper_alfardan.pdf) |
+| [Salsa20] | [`salsa20`]  | [![crates.io](https://img.shields.io/crates/v/salsa20.svg)](https://crates.io/crates/salsa20) | [![Documentation](https://docs.rs/salsa20/badge.svg)](https://docs.rs/salsa20) | ![MSRV 1.65][msrv-1.65] | 💚 |
 
 ### Security Level Legend
 
@@ -107,7 +107,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
-[msrv-1.56]: https://img.shields.io/badge/rustc-1.56.0+-blue.svg
+[msrv-1.65]: https://img.shields.io/badge/rustc-1.65.0+-blue.svg
 
 [//]: # (footnotes)
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "Criterion benchmarks of the stream-cipher crates"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [workspace]

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.9.1"
+version = "0.10.0-pre"
 description = """
 The ChaCha20 stream cipher (RFC 8439) implemented in pure Rust using traits
 from the RustCrypto `cipher` crate, with optional architecture-specific
@@ -11,7 +11,7 @@ rand_core-compatible RNGs based on those ciphers.
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/chacha20"
 repository = "https://github.com/RustCrypto/stream-ciphers"
@@ -20,14 +20,14 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 cfg-if = "1"
-cipher = "0.4.4"
+cipher = "=0.5.0-pre.1"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2"
 
 [dev-dependencies]
-cipher = { version = "0.4.4", features = ["dev"] }
-hex-literal = "0.3.3"
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 std = ["cipher/std"]

--- a/chacha20/README.md
+++ b/chacha20/README.md
@@ -64,7 +64,7 @@ stream cipher itself) are designed to execute in constant time.
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -96,7 +96,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/chacha20/badge.svg
 [docs-link]: https://docs.rs/chacha20/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260049-stream-ciphers
 [build-image]: https://github.com/RustCrypto/stream-ciphers/workflows/chacha20/badge.svg?branch=master&event=push

--- a/chacha20/src/legacy.rs
+++ b/chacha20/src/legacy.rs
@@ -2,8 +2,8 @@
 
 use super::{ChaChaCore, Key, Nonce};
 use cipher::{
+    array::Array,
     consts::{U10, U32, U64, U8},
-    generic_array::GenericArray,
     BlockSizeUser, IvSizeUser, KeyIvInit, KeySizeUser, StreamCipherCore, StreamCipherCoreWrapper,
     StreamCipherSeekCore, StreamClosure,
 };
@@ -12,7 +12,7 @@ use cipher::{
 use cipher::zeroize::ZeroizeOnDrop;
 
 /// Nonce type used by [`ChaCha20Legacy`].
-pub type LegacyNonce = GenericArray<u8, U8>;
+pub type LegacyNonce = Array<u8, U8>;
 
 /// The ChaCha20 stream cipher (legacy "djb" construction with 64-bit nonce).
 ///

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -52,7 +52,7 @@
 //! let plaintext = hex!("00010203 04050607 08090A0B 0C0D0E0F");
 //! let ciphertext = hex!("e405626e 4f1236b3 670ee428 332ea20e");
 //!
-//! // Key and IV must be references to the `GenericArray` type.
+//! // Key and IV must be references to the `Array` type.
 //! // Here we use the `Into` trait to convert arrays into it.
 //! let mut cipher = ChaCha20::new(&key.into(), &nonce.into());
 //!
@@ -113,8 +113,8 @@ pub use cipher;
 
 use cfg_if::cfg_if;
 use cipher::{
+    array::{typenum::Unsigned, Array},
     consts::{U10, U12, U32, U4, U6, U64},
-    generic_array::{typenum::Unsigned, GenericArray},
     BlockSizeUser, IvSizeUser, KeyIvInit, KeySizeUser, StreamCipherCore, StreamCipherCoreWrapper,
     StreamCipherSeekCore, StreamClosure,
 };
@@ -137,13 +137,13 @@ const CONSTANTS: [u32; 4] = [0x6170_7865, 0x3320_646e, 0x7962_2d32, 0x6b20_6574]
 const STATE_WORDS: usize = 16;
 
 /// Block type used by all ChaCha variants.
-type Block = GenericArray<u8, U64>;
+type Block = Array<u8, U64>;
 
 /// Key type used by all ChaCha variants.
-pub type Key = GenericArray<u8, U32>;
+pub type Key = Array<u8, U32>;
 
 /// Nonce type used by ChaCha variants.
-pub type Nonce = GenericArray<u8, U12>;
+pub type Nonce = Array<u8, U12>;
 
 /// ChaCha8 stream cipher (reduced-round variant of [`ChaCha20`] with 8 rounds)
 pub type ChaCha8 = StreamCipherCoreWrapper<ChaChaCore<U4>>;
@@ -205,6 +205,7 @@ impl<R: Unsigned> BlockSizeUser for ChaChaCore<R> {
 
 impl<R: Unsigned> KeyIvInit for ChaChaCore<R> {
     #[inline]
+    #[allow(clippy::let_unit_value)]
     fn new(key: &Key, iv: &Nonce) -> Self {
         let mut state = [0u32; STATE_WORDS];
         state[0..4].copy_from_slice(&CONSTANTS);

--- a/hc-256/Cargo.toml
+++ b/hc-256/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "hc-256"
-version = "0.5.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0-pre"
 description = "HC-256 Stream Cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/hc-256"
 repository = "https://github.com/RustCrypto/stream-ciphers"
@@ -13,11 +13,11 @@ keywords = ["crypto", "stream-cipher", "trait"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.4.4"
+cipher = "=0.5.0-pre.1"
 
 [dev-dependencies]
-cipher = { version = "0.4.4", features = ["dev"] }
-hex-literal = "0.3.3"
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 std = ["cipher/std"]

--- a/hc-256/README.md
+++ b/hc-256/README.md
@@ -26,7 +26,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/hc-256/badge.svg
 [docs-link]: https://docs.rs/hc-256/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg
 [hazmat-link]: https://github.com/RustCrypto/meta/blob/master/HAZMAT.md
 [build-image]: https://github.com/RustCrypto/stream-ciphers/workflows/hc-256/badge.svg?branch=master&event=push

--- a/hc-256/src/lib.rs
+++ b/hc-256/src/lib.rs
@@ -21,7 +21,7 @@
 //! let plaintext = hex!("00010203 04050607 08090A0B 0C0D0E0F");
 //! let ciphertext = hex!("ca982177 325cd40e bc208045 066c420f");
 //!
-//! // Key and IV must be references to the `GenericArray` type.
+//! // Key and IV must be references to the `Array` type.
 //! // Here we use the `Into` trait to convert arrays into it.
 //! let mut cipher = Hc256::new(&key.into(), &nonce.into());
 //!
@@ -52,8 +52,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/hc-256/0.5.0"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/rabbit/Cargo.toml
+++ b/rabbit/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rabbit"
-version = "0.4.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0-pre"
 description = "An implementation of the Rabbit Stream Cipher Algorithm"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/rabbit"
 repository = "https://github.com/RustCrypto/stream-ciphers"
@@ -13,11 +13,11 @@ keywords = ["crypto", "rabbit", "stream-cipher", "trait"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.4.4"
+cipher = "=0.5.0-pre.1"
 
 [dev-dependencies]
-cipher = { version = "0.4.4", features = ["dev"] }
-hex-literal = "0.3.3"
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 std = ["cipher/std"]

--- a/rabbit/README.md
+++ b/rabbit/README.md
@@ -26,7 +26,7 @@ architectures.
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/rabbit/badge.svg
 [docs-link]: https://docs.rs/rabbit/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260049-stream-ciphers
 [build-image]: https://github.com/RustCrypto/stream-ciphers/workflows/rabbit/badge.svg?branch=master&event=push

--- a/rabbit/src/lib.rs
+++ b/rabbit/src/lib.rs
@@ -21,7 +21,7 @@
 //! let plaintext = hex!("00010203 04050607 08090A0B 0C0D0E0F");
 //! let ciphertext = hex!("10298496 ceda18ee 0e257cbb 1ab43bcc");
 //!
-//! // Key and IV must be references to the `GenericArray` type.
+//! // Key and IV must be references to the `Array` type.
 //! // Here we use the `Into` trait to convert arrays into it.
 //! let mut cipher = Rabbit::new(&key.into(), &nonce.into());
 //!
@@ -52,8 +52,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/rabbit/0.4.1"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/rc4/Cargo.toml
+++ b/rc4/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rc4"
-version = "0.1.0"
+version = "0.2.0-pre"
 description = "Pure Rust implementation of the RC4 stream cipher"
 authors = ["The Rust-Crypto Project Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/rc4"
 repository = "https://github.com/RustCrypto/stream-ciphers"
@@ -13,10 +13,10 @@ keywords = ["arc4", "arcfour", "crypto", "stream-cipher", "trait"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.4.4"
+cipher = "=0.5.0-pre.1"
 
 [dev-dependencies]
-hex-literal = "0.3"
+hex-literal = "0.4"
 
 [features]
 std = ["cipher/std"]

--- a/rc4/README.md
+++ b/rc4/README.md
@@ -28,7 +28,7 @@ relied on for security/confidentiality.
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -60,7 +60,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/rc4/badge.svg
 [docs-link]: https://docs.rs/rc4/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260049-stream-ciphers
 [build-image]: https://github.com/RustCrypto/stream-ciphers/actions/workflows/rc4.yml/badge.svg

--- a/rc4/src/lib.rs
+++ b/rc4/src/lib.rs
@@ -25,7 +25,7 @@
 //! rc4.apply_keystream(&mut data);
 //! assert_eq!(data, [0x10, 0x21, 0xBF, 0x04, 0x20]);
 //!
-//! let key = Key::<U6>::from_slice(b"Secret");
+//! let key = Key::<U6>::ref_from_slice(b"Secret");
 //! let mut rc4 = Rc4::<_>::new(key);
 //! let mut data = b"Attack at dawn".to_vec();
 //! rc4.apply_keystream(&mut data);
@@ -38,7 +38,7 @@
 pub use cipher::{self, consts, KeyInit, StreamCipher};
 
 use cipher::{
-    generic_array::{ArrayLength, GenericArray},
+    array::{Array, ArraySize},
     Block, BlockSizeUser, KeySizeUser, ParBlocksSizeUser, StreamBackend, StreamCipherCore,
     StreamCipherCoreWrapper, StreamClosure,
 };
@@ -50,8 +50,8 @@ use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// RC4 key type (8–2048 bits/ 1-256 bytes)
 ///
-/// Implemented as an alias for [`GenericArray`].
-pub type Key<KeySize> = GenericArray<u8, KeySize>;
+/// Implemented as an alias for [`Array`].
+pub type Key<KeySize> = Array<u8, KeySize>;
 
 type BlockSize = consts::U1;
 
@@ -67,14 +67,14 @@ pub struct Rc4Core<KeySize> {
 
 impl<KeySize> KeySizeUser for Rc4Core<KeySize>
 where
-    KeySize: ArrayLength<u8>,
+    KeySize: ArraySize,
 {
     type KeySize = KeySize;
 }
 
 impl<KeySize> KeyInit for Rc4Core<KeySize>
 where
-    KeySize: ArrayLength<u8>,
+    KeySize: ArraySize,
 {
     fn new(key: &Key<KeySize>) -> Self {
         Self {
@@ -101,7 +101,7 @@ impl<KeySize> StreamCipherCore for Rc4Core<KeySize> {
 
 #[cfg(feature = "zeroize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
-impl<KeySize> ZeroizeOnDrop for Rc4Core<KeySize> where KeySize: ArrayLength<u8> {}
+impl<KeySize> ZeroizeOnDrop for Rc4Core<KeySize> where KeySize: ArraySize {}
 
 struct Backend<'a>(&'a mut Rc4State);
 

--- a/rc4/tests/lib.rs
+++ b/rc4/tests/lib.rs
@@ -32,7 +32,7 @@ fn test_rfc6229_length_40_bits_key1() {
         "
     );
 
-    let key = Key::<U5>::from_slice(&KEY);
+    let key = Key::<U5>::ref_from_slice(&KEY);
     let mut cipher = Rc4::<_>::new(key);
 
     let mut data = [0u8; 0x1010];
@@ -74,7 +74,7 @@ fn test_rfc6229_length_56_bits_key1() {
         "
     );
 
-    let key = Key::<U7>::from_slice(&KEY);
+    let key = Key::<U7>::ref_from_slice(&KEY);
     let mut cipher = Rc4::<_>::new(key);
 
     let mut data = [0u8; 0x1010];
@@ -116,7 +116,7 @@ fn test_rfc6229_length_64_bits_key1() {
         "
     );
 
-    let key = Key::<U8>::from_slice(&KEY);
+    let key = Key::<U8>::ref_from_slice(&KEY);
     let mut cipher = Rc4::<_>::new(key);
 
     let mut data = [0u8; 0x1010];
@@ -158,7 +158,7 @@ fn test_rfc6229_length_80_bits_key1() {
         "
     );
 
-    let key = Key::<U10>::from_slice(&KEY);
+    let key = Key::<U10>::ref_from_slice(&KEY);
     let mut cipher = Rc4::<_>::new(key);
 
     let mut data = [0u8; 0x1010];
@@ -201,7 +201,7 @@ fn test_rfc6229_length_128_bits_key1() {
         "
     );
 
-    let key = Key::<U16>::from_slice(&KEY);
+    let key = Key::<U16>::ref_from_slice(&KEY);
     let mut cipher = Rc4::<_>::new(key);
 
     let mut data = [0u8; 0x1010];
@@ -243,7 +243,7 @@ fn test_rfc6229_length_192_bits_key1() {
         "
     );
 
-    let key = Key::<U24>::from_slice(&KEY);
+    let key = Key::<U24>::ref_from_slice(&KEY);
     let mut cipher = Rc4::<_>::new(key);
 
     let mut data = [0u8; 0x1010];
@@ -286,7 +286,7 @@ fn test_rfc6229_length_256_bits_key1() {
         "
     );
 
-    let key = Key::<U32>::from_slice(&KEY);
+    let key = Key::<U32>::ref_from_slice(&KEY);
     let mut cipher = Rc4::<_>::new(key);
 
     let mut data = [0u8; 0x1010];
@@ -328,7 +328,7 @@ fn test_rfc6229_length_40_bits_key2() {
         "
     );
 
-    let key = Key::<U5>::from_slice(&KEY);
+    let key = Key::<U5>::ref_from_slice(&KEY);
     let mut cipher = Rc4::<_>::new(key);
 
     let mut data = [0u8; 0x1010];
@@ -370,7 +370,7 @@ fn test_rfc6229_length_56_bits_key2() {
         "
     );
 
-    let key = Key::<U7>::from_slice(&KEY);
+    let key = Key::<U7>::ref_from_slice(&KEY);
     let mut cipher = Rc4::<_>::new(key);
 
     let mut data = [0u8; 0x1010];
@@ -412,7 +412,7 @@ fn test_rfc6229_length_64_bits_key2() {
         "
     );
 
-    let key = Key::<U8>::from_slice(&KEY);
+    let key = Key::<U8>::ref_from_slice(&KEY);
     let mut cipher = Rc4::<_>::new(key);
 
     let mut data = [0u8; 0x1010];
@@ -454,7 +454,7 @@ fn test_rfc6229_length_80_bits_key2() {
         "
     );
 
-    let key = Key::<U10>::from_slice(&KEY);
+    let key = Key::<U10>::ref_from_slice(&KEY);
     let mut cipher = Rc4::<_>::new(key);
 
     let mut data = [0u8; 0x1010];
@@ -497,7 +497,7 @@ fn test_rfc6229_length_128_bits_key2() {
         "
     );
 
-    let key = Key::<U16>::from_slice(&KEY);
+    let key = Key::<U16>::ref_from_slice(&KEY);
     let mut cipher = Rc4::<_>::new(key);
 
     let mut data = [0u8; 0x1010];
@@ -539,7 +539,7 @@ fn test_rfc6229_length_192_bits_key2() {
         "
     );
 
-    let key = Key::<U24>::from_slice(&KEY);
+    let key = Key::<U24>::ref_from_slice(&KEY);
     let mut cipher = Rc4::<_>::new(key);
 
     let mut data = [0u8; 0x1010];
@@ -582,7 +582,7 @@ fn test_rfc6229_length_256_bits_key2() {
         "
     );
 
-    let key = Key::<U32>::from_slice(&KEY);
+    let key = Key::<U32>::ref_from_slice(&KEY);
     let mut cipher = Rc4::<_>::new(key);
 
     let mut data = [0u8; 0x1010];

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "salsa20"
-version = "0.10.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.11.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = "Salsa20 Stream Cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/salsa20"
 repository = "https://github.com/RustCrypto/stream-ciphers"
@@ -14,11 +14,11 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 cfg-if = "1"
-cipher = "0.4.4"
+cipher = "=0.5.0-pre.1"
 
 [dev-dependencies]
-cipher = { version = "0.4.4", features = ["dev"] }
-hex-literal = "0.3.3"
+cipher = { version = "=0.5.0-pre.1", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 std = ["cipher/std"]

--- a/salsa20/README.md
+++ b/salsa20/README.md
@@ -37,7 +37,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -69,7 +69,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/salsa20/badge.svg
 [docs-link]: https://docs.rs/salsa20/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260049-stream-ciphers
 [hazmat-image]: https://img.shields.io/badge/crypto-hazmat%E2%9A%A0-red.svg

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -34,7 +34,7 @@
 //! let plaintext = hex!("00010203 04050607 08090A0B 0C0D0E0F");
 //! let ciphertext = hex!("85843cc5 d58cce7b 5dd3dd04 fa005ded");
 //!
-//! // Key and IV must be references to the `GenericArray` type.
+//! // Key and IV must be references to the `Array` type.
 //! // Here we use the `Into` trait to convert arrays into it.
 //! let mut cipher = Salsa20::new(&key.into(), &nonce.into());
 //!
@@ -91,8 +91,8 @@ use cfg_if::cfg_if;
 pub use cipher;
 
 use cipher::{
+    array::{typenum::Unsigned, Array},
     consts::{U10, U24, U32, U4, U6, U64, U8},
-    generic_array::{typenum::Unsigned, GenericArray},
     Block, BlockSizeUser, IvSizeUser, KeyIvInit, KeySizeUser, StreamCipherCore,
     StreamCipherCoreWrapper, StreamCipherSeekCore, StreamClosure,
 };
@@ -119,13 +119,13 @@ pub type Salsa12 = StreamCipherCoreWrapper<SalsaCore<U6>>;
 pub type Salsa20 = StreamCipherCoreWrapper<SalsaCore<U10>>;
 
 /// Key type used by all Salsa variants and [`XSalsa20`].
-pub type Key = GenericArray<u8, U32>;
+pub type Key = Array<u8, U32>;
 
 /// Nonce type used by all Salsa variants.
-pub type Nonce = GenericArray<u8, U8>;
+pub type Nonce = Array<u8, U8>;
 
 /// Nonce type used by [`XSalsa20`].
-pub type XNonce = GenericArray<u8, U24>;
+pub type XNonce = Array<u8, U24>;
 
 /// Number of 32-bit words in the Salsa20 state
 const STATE_WORDS: usize = 16;

--- a/salsa20/src/xsalsa.rs
+++ b/salsa20/src/xsalsa.rs
@@ -2,8 +2,8 @@
 
 use super::{Key, Nonce, SalsaCore, Unsigned, XNonce, CONSTANTS, STATE_WORDS};
 use cipher::{
+    array::Array,
     consts::{U10, U16, U24, U32, U4, U6, U64},
-    generic_array::GenericArray,
     BlockSizeUser, IvSizeUser, KeyIvInit, KeySizeUser, StreamCipherCore, StreamCipherCoreWrapper,
     StreamCipherSeekCore, StreamClosure,
 };
@@ -40,7 +40,7 @@ impl<R: Unsigned> BlockSizeUser for XSalsaCore<R> {
 impl<R: Unsigned> KeyIvInit for XSalsaCore<R> {
     #[inline]
     fn new(key: &Key, iv: &XNonce) -> Self {
-        let subkey = hsalsa::<R>(key, iv[..16].as_ref().into());
+        let subkey = hsalsa::<R>(key, iv[..16].try_into().unwrap());
         let mut padded_iv = Nonce::default();
         padded_iv.copy_from_slice(&iv[16..]);
         XSalsaCore(SalsaCore::new(&subkey, &padded_iv))
@@ -88,7 +88,7 @@ impl<R: Unsigned> ZeroizeOnDrop for XSalsaCore<R> {}
 /// - Nonce (`u32` x 4)
 ///
 /// It produces 256-bits of output suitable for use as a Salsa20 key
-pub fn hsalsa<R: Unsigned>(key: &Key, input: &GenericArray<u8, U16>) -> GenericArray<u8, U32> {
+pub fn hsalsa<R: Unsigned>(key: &Key, input: &Array<u8, U16>) -> Array<u8, U32> {
     #[inline(always)]
     fn to_u32(chunk: &[u8]) -> u32 {
         u32::from_le_bytes(chunk.try_into().unwrap())
@@ -127,7 +127,7 @@ pub fn hsalsa<R: Unsigned>(key: &Key, input: &GenericArray<u8, U16>) -> GenericA
         quarter_round(15, 12, 13, 14, &mut state);
     }
 
-    let mut output = GenericArray::default();
+    let mut output = Array::default();
     let key_idx: [usize; 8] = [0, 5, 10, 15, 6, 7, 8, 9];
 
     for (i, chunk) in output.chunks_exact_mut(4).enumerate() {


### PR DESCRIPTION
This also bumps all of the crate versions to prereleases to denote the breaking change, however they will not have associated releases.

The main change in this prerelease of `cipher` is a migration from `generic-array` to `hybrid-array`.