### PR TITLE
Bump `cipher` to `0.5.0-pre.4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-pre.3"
+version = "0.5.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4edc902a09138d9a0d02800f2c214f15295555e4d126bf4b312ea6f3bce7ae46"
+checksum = "84fba98785cecd0e308818a87c817576a40f99d8bab6405bf422bacd3efb6c1f"
 dependencies = [
  "blobby",
  "crypto-common",

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -20,13 +20,13 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 cfg-if = "1"
-cipher = "=0.5.0-pre.3"
+cipher = "0.5.0-pre.4"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.3", features = ["dev"] }
+cipher = { version = "0.5.0-pre.4", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/hc-256/Cargo.toml
+++ b/hc-256/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "stream-cipher", "trait"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre.3"
+cipher = "0.5.0-pre.4"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.3", features = ["dev"] }
+cipher = { version = "0.5.0-pre.4", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/rabbit/Cargo.toml
+++ b/rabbit/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "rabbit", "stream-cipher", "trait"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre.3"
+cipher = "0.5.0-pre.4"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.3", features = ["dev"] }
+cipher = { version = "0.5.0-pre.4", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/rc4/Cargo.toml
+++ b/rc4/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["arc4", "arcfour", "crypto", "stream-cipher", "trait"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "=0.5.0-pre.3"
+cipher = "0.5.0-pre.4"
 
 [dev-dependencies]
 hex-literal = "0.4"

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -14,10 +14,10 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 cfg-if = "1"
-cipher = "=0.5.0-pre.3"
+cipher = "0.5.0-pre.4"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.3", features = ["dev"] }
+cipher = { version = "0.5.0-pre.4", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]


### PR DESCRIPTION
This also relax the dependency to allow for future pre-releases of `cipher`