### PR TITLE
chacha20: unify `quarter_round` in soft backend and xchacha

### DIFF
--- a/chacha20/src/backends/soft.rs
+++ b/chacha20/src/backends/soft.rs
@@ -1,7 +1,7 @@
 //! Portable implementation which does not rely on architecture-specific
 //! intrinsics.
 
-use crate::{ChaChaCore, Rounds, Variant, STATE_WORDS};
+use crate::{quarter_round, ChaChaCore, Rounds, Variant, STATE_WORDS};
 
 #[cfg(feature = "cipher")]
 use crate::chacha::Block;
@@ -73,23 +73,4 @@ fn run_rounds<R: Rounds>(state: &[u32; STATE_WORDS]) -> [u32; STATE_WORDS] {
         *s1 = s1.wrapping_add(*s0);
     }
     res
-}
-
-/// The ChaCha20 quarter round function
-fn quarter_round(a: usize, b: usize, c: usize, d: usize, state: &mut [u32; STATE_WORDS]) {
-    state[a] = state[a].wrapping_add(state[b]);
-    state[d] ^= state[a];
-    state[d] = state[d].rotate_left(16);
-
-    state[c] = state[c].wrapping_add(state[d]);
-    state[b] ^= state[c];
-    state[b] = state[b].rotate_left(12);
-
-    state[a] = state[a].wrapping_add(state[b]);
-    state[d] ^= state[a];
-    state[d] = state[d].rotate_left(8);
-
-    state[c] = state[c].wrapping_add(state[d]);
-    state[b] ^= state[c];
-    state[b] = state[b].rotate_left(7);
 }

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -343,3 +343,31 @@ impl<R: Rounds, V: Variant> Drop for ChaChaCore<R, V> {
 #[cfg(feature = "zeroize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 impl<R: Rounds, V: Variant> ZeroizeOnDrop for ChaChaCore<R, V> {}
+
+/// The ChaCha20 quarter round function
+///
+/// We located this function in the root of the crate as we want it to be available
+/// for the soft backend and for xchacha.
+pub(crate) fn quarter_round(
+    a: usize,
+    b: usize,
+    c: usize,
+    d: usize,
+    state: &mut [u32; STATE_WORDS],
+) {
+    state[a] = state[a].wrapping_add(state[b]);
+    state[d] ^= state[a];
+    state[d] = state[d].rotate_left(16);
+
+    state[c] = state[c].wrapping_add(state[d]);
+    state[b] ^= state[c];
+    state[b] = state[b].rotate_left(12);
+
+    state[a] = state[a].wrapping_add(state[b]);
+    state[d] ^= state[a];
+    state[d] = state[d].rotate_left(8);
+
+    state[c] = state[c].wrapping_add(state[d]);
+    state[b] ^= state[c];
+    state[b] = state[b].rotate_left(7);
+}

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -348,6 +348,7 @@ impl<R: Rounds, V: Variant> ZeroizeOnDrop for ChaChaCore<R, V> {}
 ///
 /// We located this function in the root of the crate as we want it to be available
 /// for the soft backend and for xchacha.
+#[allow(dead_code)]
 pub(crate) fn quarter_round(
     a: usize,
     b: usize,

--- a/chacha20/src/xchacha.rs
+++ b/chacha20/src/xchacha.rs
@@ -7,7 +7,9 @@ use cipher::{
     StreamCipherSeekCore, StreamClosure,
 };
 
-use crate::{variants::Ietf, ChaChaCore, Rounds, CONSTANTS, R12, R20, R8, STATE_WORDS};
+use crate::{
+    quarter_round, variants::Ietf, ChaChaCore, Rounds, CONSTANTS, R12, R20, R8, STATE_WORDS,
+};
 
 #[cfg(feature = "zeroize")]
 use zeroize::ZeroizeOnDrop;
@@ -149,26 +151,6 @@ pub fn hchacha<R: Rounds>(key: &Key, input: &Array<u8, U16>) -> Array<u8, U32> {
     }
 
     output
-}
-
-/// The ChaCha20 quarter round function
-// for simplicity this function is copied from the software backend
-fn quarter_round(a: usize, b: usize, c: usize, d: usize, state: &mut [u32; STATE_WORDS]) {
-    state[a] = state[a].wrapping_add(state[b]);
-    state[d] ^= state[a];
-    state[d] = state[d].rotate_left(16);
-
-    state[c] = state[c].wrapping_add(state[d]);
-    state[b] ^= state[c];
-    state[b] = state[b].rotate_left(12);
-
-    state[a] = state[a].wrapping_add(state[b]);
-    state[d] ^= state[a];
-    state[d] = state[d].rotate_left(8);
-
-    state[c] = state[c].wrapping_add(state[d]);
-    state[b] ^= state[c];
-    state[b] = state[b].rotate_left(7);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The `quarter_round` function is duplicated inside xchacha. We can just use the soft backend version, which is the same code.

https://github.com/RustCrypto/stream-ciphers/pull/348#pullrequestreview-1958048341