### PR TITLE
chacha20: fix warnings

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.71.0
+          toolchain: 1.78.0
           components: clippy
       - run: cargo clippy --all -- -D warnings
 

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -108,6 +108,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 #![allow(clippy::needless_range_loop)]
+#![allow(unexpected_cfgs)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
 
 #[cfg(feature = "cipher")]


### PR DESCRIPTION
Fixes new Clippy warnings and silences the new `unexpected_cfgs` Nightly lint. Additionally, bumps Clippy version used in CI to 1.78.