### PR TITLE
chacha20: remove `chacha20_force_neon` cfg attribute

### DIFF
--- a/.github/workflows/chacha20.yml
+++ b/.github/workflows/chacha20.yml
@@ -43,7 +43,7 @@ jobs:
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
-        working-directory: ${{ github.workflow }}
+      working-directory: ${{ github.workflow }}
 
   # Tests for runtime AVX2 detection
   autodetect:
@@ -186,11 +186,6 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             rust: stable
 
-          # ARM64 with NEON backend
-          - target: aarch64-unknown-linux-gnu
-            rust: stable
-            rustflags: --cfg chacha20_force_neon
-
           # PPC32
           - target: powerpc-unknown-linux-gnu
             rust: 1.65.0 # MSRV
@@ -201,7 +196,7 @@ jobs:
     defaults:
       run:
         # Cross mounts only current package, i.e. by default it ignores workspace's Cargo.toml
-        working-directory: .  
+        working-directory: .
     steps:
       - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master

--- a/chacha20/src/backends.rs
+++ b/chacha20/src/backends.rs
@@ -15,7 +15,7 @@ cfg_if! {
                 pub(crate) mod sse2;
             }
         }
-    } else if #[cfg(all(chacha20_force_neon, target_arch = "aarch64", target_feature = "neon"))] {
+    } else if #[cfg(all(target_arch = "aarch64", target_feature = "neon"))] {
         pub(crate) mod neon;
     } else {
         pub(crate) mod soft;

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -86,8 +86,6 @@
 //!
 //! - `chacha20_force_avx2`: force AVX2 backend on x86/x86_64 targets.
 //!   Requires enabled AVX2 target feature. Ignored on non-x86(-64) targets.
-//! - `chacha20_force_neon`: force NEON backend on ARM targets.
-//!   Requires enabled NEON target feature. Ignored on non-ARM targets. Nightly-only.
 //! - `chacha20_force_soft`: force software backend.
 //! - `chacha20_force_sse2`: force SSE2 backend on x86/x86_64 targets.
 //!   Requires enabled SSE2 target feature. Ignored on non-x86(-64) targets.
@@ -317,7 +315,7 @@ impl<R: Rounds, V: Variant> StreamCipherCore for ChaChaCore<R, V> {
                         }
                     }
                 }
-            } else if #[cfg(all(chacha20_force_neon, target_arch = "aarch64", target_feature = "neon"))] {
+            } else if #[cfg(all(target_arch = "aarch64", target_feature = "neon"))] {
                 unsafe {
                     backends::neon::inner::<R, _>(&mut self.state, f);
                 }

--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -219,7 +219,7 @@ impl<R: Rounds, V: Variant> ChaChaCore<R, V> {
                         }
                     }
                 }
-            } else if #[cfg(all(chacha20_force_neon, target_arch = "aarch64", target_feature = "neon"))] {
+            } else if #[cfg(all(target_arch = "aarch64", target_feature = "neon"))] {
                 unsafe {
                     backends::neon::rng_inner::<R, V>(self, buffer);
                 }


### PR DESCRIPTION
Enables this functionality by default on `aarch64` targets, all of which have NEON by definition.

The reason it was previously gated like this was because it required what was previously nightly-only functionality, however such functionality has since been stabilized.