### PR TITLE
chacha20+salsa20: cut pre.1 prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-pre"
+version = "0.10.0-pre.1"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -202,7 +202,7 @@ checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "salsa20"
-version = "0.11.0-pre"
+version = "0.11.0-pre.1"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.10.0-pre"
+version = "0.10.0-pre.1"
 description = """
 The ChaCha20 stream cipher (RFC 8439) implemented in pure Rust using traits
 from the RustCrypto `cipher` crate, with optional architecture-specific
@@ -20,7 +20,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 cfg-if = "1"
-cipher = { version = "=0.5.0-pre.6", optional = true}
+cipher = { version = "=0.5.0-pre.6", optional = true }
 rand_core = { version = "0.9.0-alpha.1", optional = true, default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
 zeroize = { version = "1.8.1", optional = true }

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa20"
-version = "0.11.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.11.0-pre.1"
 description = "Salsa20 Stream Cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/salsa20/src/lib.rs
+++ b/salsa20/src/lib.rs
@@ -70,8 +70,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/salsa20/0.10.2"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
 


### PR DESCRIPTION
Cuts the following prereleases:
- `chacha20` v0.10.0-pre.1
- `salsa20` v0.11.0-pre.1