### PR TITLE
build(deps): bump rand_core from 0.9.0-alpha.1 to 0.9.0-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
  "cpufeatures",
  "hex-literal",
  "rand_chacha",
- "rand_core 0.9.0-alpha.1",
+ "rand_core 0.9.0-alpha.2",
  "serde",
  "serde_json",
  "zeroize",
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.0-alpha.1"
+version = "0.9.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc89dffba8377c5ec847d12bb41492bda235dba31a25e8b695cd0fe6589eb8c9"
+checksum = "f4e93f5a5e3c528cda9acb0928c31b2ba868c551cc46e67b778075e34aab9906"
 dependencies = [
  "zerocopy",
 ]
@@ -271,18 +271,18 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.0-alpha.6"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db678a6ee512bd06adf35c35be471cae2f9c82a5aed2b5d15e03628c98bddd57"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.0-alpha.6"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201585ea96d37ee69f2ac769925ca57160cef31acb137c16f38b02b76f4c1e62"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -21,7 +21,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 cfg-if = "1"
 cipher = { version = "=0.5.0-pre.7", optional = true }
-rand_core = { version = "0.9.0-alpha.1", optional = true, default-features = false }
+rand_core = { version = "0.9.0-alpha.2", optional = true, default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
 zeroize = { version = "1.8.1", optional = true }
 

--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -10,7 +10,7 @@ use core::fmt::Debug;
 
 use rand_core::{
     block::{BlockRng, BlockRngCore, CryptoBlockRng},
-    CryptoRng, Error, RngCore, SeedableRng,
+    impl_try_rng_from_rng_core, CryptoRng, RngCore, SeedableRng,
 };
 
 #[cfg(feature = "serde1")]
@@ -382,11 +382,9 @@ macro_rules! impl_chacha_rng {
             fn fill_bytes(&mut self, dest: &mut [u8]) {
                 self.core.fill_bytes(dest)
             }
-            #[inline]
-            fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-                Ok(self.fill_bytes(dest))
-            }
         }
+
+        impl_try_rng_from_rng_core!($ChaChaXRng);
 
         impl $ChaChaXRng {
             // The buffer is a 4-block window, i.e. it is always at a block-aligned position in the
@@ -733,7 +731,7 @@ pub(crate) mod tests {
         let mut rng1 = ChaChaRng::from_seed(seed);
         assert_eq!(rng1.next_u32(), 137206642);
 
-        let mut rng2 = ChaChaRng::from_rng(rng1).unwrap();
+        let mut rng2 = ChaChaRng::from_rng(rng1);
         assert_eq!(rng2.next_u32(), 1325750369);
     }
 


### PR DESCRIPTION
`rand_core` reworked its error management and now return Infallible error.