### PR TITLE
chacha20+salsa20: cut pre.2 prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-pre.1"
+version = "0.10.0-pre.2"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -202,7 +202,7 @@ checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "salsa20"
-version = "0.11.0-pre.1"
+version = "0.11.0-pre.2"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.10.0-pre.1"
+version = "0.10.0-pre.2"
 description = """
 The ChaCha20 stream cipher (RFC 8439) implemented in pure Rust using traits
 from the RustCrypto `cipher` crate, with optional architecture-specific

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa20"
-version = "0.11.0-pre.1"
+version = "0.11.0-pre.2"
 description = "Salsa20 Stream Cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Cuts the following prereleases:
- `chacha20` v0.10.0-pre.2
- `salsa20` v0.11.0-pre.2