### PR TITLE
Improved SSE2 throughput by up to +90%

### DIFF
--- a/chacha20/README.md
+++ b/chacha20/README.md
@@ -31,7 +31,7 @@ work on stable Rust with the following `RUSTFLAGS`:
 
 - `x86` / `x86_64`
   - `avx2`: (~1.4cpb) `-Ctarget-cpu=haswell -Ctarget-feature=+avx2`
-  - `sse2`: (~2.5cpb) `-Ctarget-feature=+sse2` (on by default on x86 CPUs)
+  - `sse2`: (~1.6cpb) `-Ctarget-feature=+sse2` (on by default on x86 CPUs)
 - `aarch64`
   - `neon` (~2-3x faster than `soft`) requires Rust 1.61+ and the `neon` feature enabled
 - Portable

--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -10,7 +10,7 @@ use core::fmt::Debug;
 
 use rand_core::{
     block::{BlockRng, BlockRngCore, CryptoBlockRng},
-    impl_try_rng_from_rng_core, CryptoRng, RngCore, SeedableRng,
+    CryptoRng, RngCore, SeedableRng,
 };
 
 #[cfg(feature = "serde1")]
@@ -32,12 +32,18 @@ const BLOCK_WORDS: u8 = 16;
 
 /// The seed for ChaCha20. Implements ZeroizeOnDrop when the
 /// zeroize feature is enabled.
-#[derive(PartialEq, Eq, Default)]
+#[derive(PartialEq, Eq, Default, Clone)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct Seed([u8; 32]);
 
 impl AsRef<[u8; 32]> for Seed {
     fn as_ref(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for Seed {
+    fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
@@ -383,8 +389,6 @@ macro_rules! impl_chacha_rng {
                 self.core.fill_bytes(dest)
             }
         }
-
-        impl_try_rng_from_rng_core!($ChaChaXRng);
 
         impl $ChaChaXRng {
             // The buffer is a 4-block window, i.e. it is always at a block-aligned position in the


### PR DESCRIPTION
By changing the output buffer for the SSE2 backend to 4 blocks, I was able to improve the performance by +83% more throughput for `cipher` and +90% more throughput for the `rng`
Closes #379 