### PR TITLE
chacha20 v0.10.0-pre.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-pre.2"
+version = "0.10.0-pre.3"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.10.0-pre.2"
+version = "0.10.0-pre.3"
 description = """
 The ChaCha20 stream cipher (RFC 8439) implemented in pure Rust using traits
 from the RustCrypto `cipher` crate, with optional architecture-specific


### PR DESCRIPTION
Note: this release supports `rand_core` v0.9