### PR TITLE
chacha20: rng - Fixing NEON Backend

### DIFF
--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -1115,4 +1115,23 @@ pub(crate) mod tests {
         let expected = 2059058063;
         assert_eq!(rng.next_u32(), expected);
     }
+
+    /// If this test fails, the backend may be
+    /// performing 64-bit addition.
+    #[test]
+    fn counter_wrapping() {
+        let mut rng = ChaChaRng::from_seed([0u8; 32]);
+
+        // get first four blocks and word pos
+        let mut first_blocks = [0u8; 64 * 4];
+        rng.fill_bytes(&mut first_blocks);
+        let word_pos = rng.get_word_pos();
+
+        // get first four blocks after wrapping
+        rng.set_block_pos(u32::MAX);
+        let mut result = [0u8; 64 * 5];
+        rng.fill_bytes(&mut result);
+        assert_eq!(word_pos, rng.get_word_pos());
+        assert_eq!(&first_blocks[0..64 * 4], &result[64..]);
+    }
 }

--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -1117,7 +1117,7 @@ pub(crate) mod tests {
         rng.set_stream(1234567);
         let expected = 1254506509;
         assert_eq!(rng.next_u32(), expected);
-        rng.set_stream([1,2,3,4,5,6,7,8,9,10,11,12]);
+        rng.set_stream([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
         let expected = 1391671567;
         assert_eq!(rng.next_u32(), expected);
     }

--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -1114,6 +1114,12 @@ pub(crate) mod tests {
         rng.set_stream([3, 3333, 333333]);
         let expected = 2059058063;
         assert_eq!(rng.next_u32(), expected);
+        rng.set_stream(1234567);
+        let expected = 1254506509;
+        assert_eq!(rng.next_u32(), expected);
+        rng.set_stream([1,2,3,4,5,6,7,8,9,10,11,12]);
+        let expected = 1391671567;
+        assert_eq!(rng.next_u32(), expected);
     }
 
     /// If this test fails, the backend may be


### PR DESCRIPTION
fixes #381 
seeing if the test fails on github actions; it fails on my Mac with `cargo test --features rng` and passes with `RUSTFLAGS="--cfg chacha20_force_soft"`

Once this is fixed, there *should be* no more bugs with the RNG. I might add one more endian test for peace of mind though.