### PR TITLE
[WIP] 64-bit counters for legacy and XChaCha variants, fix looping counter regressions

### DIFF
--- a/.github/workflows/chacha20.yml
+++ b/.github/workflows/chacha20.yml
@@ -37,7 +37,8 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
-      - run: cargo build --target ${{ matrix.target }}
+      - run: cargo build --target ${{ matrix.target }} --features xchacha,legacy
+      - run: bash -c '[[ $(cargo test --features xchacha,legacy overflow -- --list --format=terse 2>/dev/null | wc -l) -eq 14 ]]'
       - run: cargo build --target ${{ matrix.target }} --features zeroize
 
   minimal-versions:
@@ -73,7 +74,7 @@ jobs:
           targets: ${{ matrix.target }}
       - run: ${{ matrix.deps }}
       - run: cargo check --target ${{ matrix.target }} --all-features
-      - run: cargo test --target ${{ matrix.target }}
+      - run: cargo test --target ${{ matrix.target }} --features xchacha,legacy
       - run: cargo test --target ${{ matrix.target }} --features zeroize
 
   # Tests for the AVX2 backend
@@ -106,7 +107,7 @@ jobs:
           targets: ${{ matrix.target }}
       - run: ${{ matrix.deps }}
       - run: cargo check --target ${{ matrix.target }} --all-features
-      - run: cargo test --target ${{ matrix.target }}
+      - run: cargo test --target ${{ matrix.target }} --features xchacha,legacy
       - run: cargo test --target ${{ matrix.target }} --features zeroize
 
   # Tests for the SSE2 backend
@@ -139,7 +140,7 @@ jobs:
           targets: ${{ matrix.target }}
       - run: ${{ matrix.deps }}
       - run: cargo check --target ${{ matrix.target }} --all-features
-      - run: cargo test --target ${{ matrix.target }}
+      - run: cargo test --target ${{ matrix.target }} --features xchacha,legacy
       - run: cargo test --target ${{ matrix.target }} --features zeroize
 
   # Tests for the portable software backend
@@ -172,7 +173,7 @@ jobs:
           targets: ${{ matrix.target }}
       - run: ${{ matrix.deps }}
       - run: cargo check --target ${{ matrix.target }} --all-features
-      - run: cargo test --target ${{ matrix.target }}
+      - run: cargo test --target ${{ matrix.target }} --features xchacha,legacy
       - run: cargo test --target ${{ matrix.target }} --features zeroize
 
   # Cross-compiled tests
@@ -206,4 +207,4 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cross-install@master
-      - run: RUSTFLAGS="${{ matrix.rustflags }}" cross test --package chacha20 --target ${{ matrix.target }}
+      - run: RUSTFLAGS="${{ matrix.rustflags }}" cross test --package chacha20 --target ${{ matrix.target }} --features xchacha,legacy

--- a/chacha20/src/variants.rs
+++ b/chacha20/src/variants.rs
@@ -6,6 +6,10 @@
 pub trait Variant: Clone {
     /// the size of the Nonce in u32s
     const NONCE_INDEX: usize;
+    /// the number of u32s used for the counter
+    const COUNTER_SIZE: usize;
+    /// the maximum counter value with available keystream
+    const MAX_USABLE_COUNTER: u64 = (u64::MAX >> ((2 - Self::COUNTER_SIZE) * 32));
 }
 
 #[derive(Clone)]
@@ -13,6 +17,17 @@ pub trait Variant: Clone {
 pub struct Ietf();
 impl Variant for Ietf {
     const NONCE_INDEX: usize = 13;
+    const COUNTER_SIZE: usize = 1;
+}
+
+#[derive(Clone)]
+#[cfg(feature = "xchacha")]
+pub struct XChaCha();
+
+#[cfg(feature = "xchacha")]
+impl Variant for XChaCha {
+    const NONCE_INDEX: usize = 14;
+    const COUNTER_SIZE: usize = 2;
 }
 
 #[derive(Clone)]
@@ -22,4 +37,5 @@ pub struct Legacy();
 #[cfg(feature = "legacy")]
 impl Variant for Legacy {
     const NONCE_INDEX: usize = 14;
+    const COUNTER_SIZE: usize = 2;
 }

--- a/chacha20/tests/mod.rs
+++ b/chacha20/tests/mod.rs
@@ -234,3 +234,205 @@ mod legacy {
         }
     }
 }
+
+
+mod overflow {
+    use cipher::{StreamCipher, StreamCipherSeek};
+    use chacha20::KeyIvInit;
+
+    const OFFSET_256GB: u64 = 256u64 << 30;
+    const OFFSET_256PB: u64 = 256u64 << 50;
+    const OFFSET_1ZB: u128 = (64u128) << 64;
+
+    #[test]
+    fn bad_overflow_check1() {
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(), &Default::default());
+        cipher
+            .try_seek(OFFSET_256GB - 1)
+            .expect("Couldn't seek to nearly 256GB");
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect("Couldn't encrypt the last byte of 256GB");
+        assert_eq!(cipher.try_current_pos::<u64>().unwrap(), OFFSET_256GB);
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect_err("Could encrypt past the last byte of 256GB");
+    }
+
+    #[test]
+    fn bad_overflow_check2() {
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(), &Default::default());
+        cipher
+            .try_seek(OFFSET_256GB - 1)
+            .expect("Couldn't seek to nearly 256GB");
+        let mut data = [0u8; 2];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect_err("Could encrypt over the 256GB boundary");
+    }
+
+    #[test]
+    fn bad_overflow_check3() {
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(), &Default::default());
+        cipher
+            .try_seek(OFFSET_256GB - 1)
+            .expect("Couldn't seek to nearly 256GB");
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect("Couldn't encrypt the last byte of 256GB");
+        assert_eq!(cipher.try_current_pos::<u64>().unwrap(), OFFSET_256GB);
+        let mut data = [0u8; 63];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect_err("Could encrypt past the last byte of 256GB");
+    }
+
+    #[test]
+    fn bad_overflow_check4() {
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(), &Default::default());
+        cipher
+            .try_seek(OFFSET_256GB - 1)
+            .expect("Couldn't seek to nearly 256GB");
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect("Couldn't encrypt the last byte of 256GB");
+        assert_eq!(cipher.try_current_pos::<u64>().unwrap(), OFFSET_256GB);
+        let mut data = [0u8; 64];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect_err("Could encrypt past the last byte of 256GB");
+    }
+
+    #[test]
+    fn bad_overflow_check5() {
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(), &Default::default());
+        cipher
+            .try_seek(OFFSET_256GB - 1)
+            .expect("Couldn't seek to nearly 256GB");
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect("Couldn't encrypt the last byte of 256GB");
+        assert_eq!(cipher.try_current_pos::<u64>().unwrap(), OFFSET_256GB);
+        let mut data = [0u8; 65];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect_err("Could encrypt past the last byte of 256GB");
+    }
+
+    #[test]
+    fn bad_overflow_check6() {
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(), &Default::default());
+        cipher
+            .try_seek(OFFSET_256GB)
+            .expect_err("Could seek to 256GB");
+    }
+
+    #[test]
+    fn bad_overflow_check7() {
+        let mut cipher = chacha20::ChaCha20::new(&Default::default(), &Default::default());
+        if let Ok(()) = cipher.try_seek(OFFSET_256GB + 63) {
+            let mut data = [0u8; 1];
+            cipher
+                .try_apply_keystream(&mut data)
+                .expect_err("Could encrypt the 64th byte past the 256GB boundary");
+        }
+    }
+
+    #[test]
+#[cfg(feature = "xchacha")]
+    fn xchacha_256gb() {
+        let mut cipher = chacha20::XChaCha20::new(&Default::default(), &Default::default());
+        cipher
+            .try_seek(OFFSET_256GB - 1)
+            .expect("Couldn't seek to nearly 256GB");
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect("Couldn't encrypt the last byte of 256GB");
+        assert_eq!(cipher.try_current_pos::<u64>().unwrap(), OFFSET_256GB);
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect("Couldn't encrypt past the last byte of 256GB");
+    }
+
+    #[test]
+#[cfg(feature = "xchacha")]
+    fn xchacha_upper_limit() {
+        let mut cipher = chacha20::XChaCha20::new(&Default::default(), &Default::default());
+        cipher
+            .try_seek(OFFSET_1ZB - 1)
+            .expect("Couldn't seek to nearly 1 zebibyte");
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect("Couldn't encrypt the last byte of 1 zebibyte");
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect_err("Could encrypt past 1 zebibyte");
+    }
+
+    #[test]
+#[cfg(feature = "xchacha")]
+    fn xchacha_has_a_big_counter() {
+        let mut cipher = chacha20::XChaCha20::new(&Default::default(), &Default::default());
+        cipher.try_seek(OFFSET_256PB).expect("Could seek to 256PB");
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect("Couldn't encrypt the next byte after 256PB");
+    }
+
+    #[cfg(feature = "legacy")]
+    #[test]
+    fn legacy_256gb() {
+        let mut cipher = chacha20::ChaCha20Legacy::new(&Default::default(), &Default::default());
+        cipher
+            .try_seek(OFFSET_256GB - 1)
+            .expect("Couldn't seek to nearly 256GB");
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect("Couldn't encrypt the last byte of 256GB");
+        assert_eq!(cipher.try_current_pos::<u64>().unwrap(), OFFSET_256GB);
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect("Couldn't encrypt past the last byte of 256GB");
+    }
+
+    #[cfg(feature = "legacy")]
+    #[test]
+    fn legacy_upper_limit() {
+        let mut cipher = chacha20::ChaCha20Legacy::new(&Default::default(), &Default::default());
+        cipher
+            .try_seek(OFFSET_1ZB - 1)
+            .expect("Couldn't seek to nearly 1 zebibyte");
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect("Couldn't encrypt the last byte of 1 zebibyte");
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect_err("Could encrypt past 1 zebibyte");
+    }
+
+    #[cfg(feature = "legacy")]
+    #[test]
+    fn legacy_has_a_big_counter() {
+        let mut cipher = chacha20::ChaCha20Legacy::new(&Default::default(), &Default::default());
+        cipher.try_seek(OFFSET_256PB).expect("Could seek to 256PB");
+        let mut data = [0u8; 1];
+        cipher
+            .try_apply_keystream(&mut data)
+            .expect("Couldn't encrypt the next byte after 256PB");
+    }
+}
+


### PR DESCRIPTION
This is still WIP. So far it is basically a PoC of what is needed to perform these changes.
The overall checklist before merging is:
- [x] Restore the deleted regression tests
- [x] Correct handling of the full 256GB key stream in `Ietf` ChaCha20
- [x] Correct handling of 64-bit counters in legacy and xchacha variants
- [x] ChaCha20 software backend cipher-mode support
- [x] ChaCha20 SSE2 backend cipher-mode support
- [ ] ChaCha20 RNG mode support
- [ ] ChaCha20 AVX2 support
- [ ] ChaCha20 NEON support
- [ ] Salsa20 software backend support
- [ ] Salsa20 SSE2 backend support
- [ ] Salsa20 AVX2 backend support 
- [ ] Salsa20 NEON backend support
- [ ] Update `traits` so that there is an explicit representation of a looped/saturated counter. Currently the implementation of StreamCipherCoreWrapper does not allow me to directly implement a cipher that stops once it would loop; in the current implementation I get around this by effectively using a 64-bit counter for the 32-bit counter mode, which allows me to distinguish between a just-initialized cipher (`block_pos = 0, pos = 64`) and a looped cipher (`block_pos = 2**32, pos = 64`). Note that this does not currently allow correct behavior at the end of a 64-bit-counter keystream.
- [ ] Convert the `Ietf` variant to use a 32-bit counter again, fixing the `bad_overflow_check{6,7}` seek-focused tests 
- [ ] Update the arithmetic in `SeekNum::from_block_byte` in `traits` to match the looped counter representation, thereby fixing https://github.com/RustCrypto/traits/issues/1808. (NOTE: the test in that issue is present in this PR, and succeeds; that is because I use a 64-bit overall counter even in 32-bit `Ietf` mode)

This would close https://github.com/RustCrypto/stream-ciphers/issues/334, https://github.com/RustCrypto/stream-ciphers/issues/391.