### PR TITLE
cipher v0.5.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-pre.3"
+version = "0.10.0-rc.0"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-pre.8"
+version = "0.5.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276974d2acb7cf592603150941fc1ff6442acdeb1dc653ac2825928f4703c131"
+checksum = "bd4ef774202f1749465fc7cf88d70fc30620e8cacd5429268f4bff7d003bd976"
 dependencies = [
  "blobby",
  "crypto-common",
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170d71b5b14dec99db7739f6fc7d6ec2db80b78c3acb77db48392ccc3d8a9ea0"
+checksum = "8a23fa214dea9efd4dacee5a5614646b30216ae0f05d4bb51bafb50e9da1c5be"
 dependencies = [
  "hybrid-array",
 ]
@@ -211,7 +211,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "salsa20"
-version = "0.11.0-pre.2"
+version = "0.11.0-rc.0"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.10.0-pre.3"
+version = "0.10.0-rc.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -20,7 +20,7 @@ rand_core-compatible RNGs based on those ciphers.
 
 [dependencies]
 cfg-if = "1"
-cipher = { version = "=0.5.0-pre.8", optional = true }
+cipher = { version = "0.5.0-rc.0", optional = true }
 rand_core = { version = "0.9", optional = true, default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
@@ -31,7 +31,7 @@ zeroize = { version = "1.8.1", optional = true, default-features = false }
 cpufeatures = "0.2"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.8", features = ["dev"] }
+cipher = { version = "0.5.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 rand_chacha = "0.9"
 serde_json = "1.0" # Only to test serde1

--- a/hc-256/Cargo.toml
+++ b/hc-256/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["cryptography", "no-std"]
 description = "Pure Rust implementation of the HC-256 stream cipher"
 
 [dependencies]
-cipher = "=0.5.0-pre.8"
+cipher = "0.5.0-rc.0"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.8", features = ["dev"] }
+cipher = { version = "0.5.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/rabbit/Cargo.toml
+++ b/rabbit/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["cryptography", "no-std"]
 description = "Pure Rust implementation of the Rabbit stream cipher"
 
 [dependencies]
-cipher = "=0.5.0-pre.8"
+cipher = "0.5.0-rc.0"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.8", features = ["dev"] }
+cipher = { version = "0.5.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/rc4/Cargo.toml
+++ b/rc4/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 description = "Pure Rust implementation of the RC4 stream cipher"
 
 [dependencies]
-cipher = "=0.5.0-pre.8"
+cipher = "0.5.0-rc.0"
 
 [dev-dependencies]
 hex-literal = "1"

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa20"
-version = "0.11.0-pre.2"
+version = "0.11.0-rc.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -14,10 +14,10 @@ description = "Pure Rust implementation of the Salsa20 stream cipher"
 
 [dependencies]
 cfg-if = "1"
-cipher = "=0.5.0-pre.8"
+cipher = "0.5.0-rc.0"
 
 [dev-dependencies]
-cipher = { version = "=0.5.0-pre.8", features = ["dev"] }
+cipher = { version = "0.5.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 
 [features]


### PR DESCRIPTION
Also cuts `rc.0` releases of `chacha20` and `salsa20`