### PR TITLE
Misc. tweaks

### DIFF
--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -47,3 +47,14 @@ xchacha = ["cipher"]
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+  'cfg(chacha20_force_soft)',
+  'cfg(chacha20_force_sse2)',
+  'cfg(chacha20_force_avx2)',
+]
+
+[lints.clippy]
+needless_range_loop = "allow"

--- a/chacha20/src/backends/sse2.rs
+++ b/chacha20/src/backends/sse2.rs
@@ -116,7 +116,8 @@ where
 #[cfg(feature = "rng")]
 impl<R: Rounds> Backend<R> {
     #[inline(always)]
-    fn gen_ks_blocks(&mut self, block: &mut [u32]) {
+    fn gen_ks_blocks(&mut self, block: &mut [u32; 64]) {
+        const _: () = assert!(4 * PAR_BLOCKS * size_of::<__m128i>() == size_of::<[u32; 64]>());
         unsafe {
             let res = rounds::<R>(&self.v);
             self.v[3] = _mm_add_epi32(self.v[3], _mm_set_epi32(0, 0, 0, PAR_BLOCKS as i32));

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -226,10 +226,13 @@ impl<R: Rounds, V: Variant> ChaChaCore<R, V> {
     fn new(key: &[u8; 32], iv: &[u8]) -> Self {
         let mut state = [0u32; STATE_WORDS];
         state[0..4].copy_from_slice(&CONSTANTS);
+
         let key_chunks = key.chunks_exact(4);
         for (val, chunk) in state[4..12].iter_mut().zip(key_chunks) {
             *val = u32::from_le_bytes(chunk.try_into().unwrap());
         }
+
+        assert_eq!(iv.len(), 4 * (16 - V::NONCE_INDEX));
         let iv_chunks = iv.as_ref().chunks_exact(4);
         for (val, chunk) in state[V::NONCE_INDEX..16].iter_mut().zip(iv_chunks) {
             *val = u32::from_le_bytes(chunk.try_into().unwrap());

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -105,8 +105,6 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
-#![allow(clippy::needless_range_loop)]
-#![allow(unexpected_cfgs)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
 
 #[cfg(feature = "cipher")]

--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -362,10 +362,6 @@ macro_rules! impl_chacha_rng {
             #[inline]
             fn generate(&mut self, r: &mut Self::Results) {
                 self.0.generate(&mut r.0);
-                #[cfg(target_endian = "big")]
-                for word in r.0.iter_mut() {
-                    *word = word.to_le();
-                }
             }
         }
 

--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -214,7 +214,6 @@ const BUF_BLOCKS: u8 = BUFFER_SIZE as u8 >> 4;
 impl<R: Rounds, V: Variant> ChaChaCore<R, V> {
     /// Generates 4 blocks in parallel with avx2 & neon, but merely fills
     /// 4 blocks with sse2 & soft
-    #[cfg(feature = "rand_core")]
     fn generate(&mut self, buffer: &mut [u32; 64]) {
         cfg_if! {
             if #[cfg(chacha20_force_soft)] {

--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -744,6 +744,8 @@ pub(crate) mod tests {
         let mut rng1 = ChaChaRng::from_seed(seed);
         assert_eq!(rng1.next_u32(), 137206642);
 
+        assert_eq!(rng1.get_seed(), seed);
+
         let mut rng2 = ChaChaRng::from_rng(&mut rng1);
         assert_eq!(rng2.next_u32(), 1325750369);
     }


### PR DESCRIPTION
I've had a look over the `chacha20` code pertaining to RNG usage (so ignoring anything behind feature "cipher"; also not paying much attention to "xchacha" or "zeroize"). This PR is just a few little things.

Can I ask why the block generation size is fixed at 64 words? Is it just to ensure the size is the same across backends? And yet even the AVX2 backend looks like it's generating double the output required by the level of parallelism.