### PR TITLE
Cut prereleases with `hybrid-array` v0.4 support (#1210)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.0"
+version = "0.10.0-rc.1"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -361,7 +361,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "salsa20"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20"
-version = "0.10.0-rc.0"
+version = "0.10.0-rc.1"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
@@ -51,9 +51,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-  'cfg(chacha20_force_soft)',
-  'cfg(chacha20_force_sse2)',
-  'cfg(chacha20_force_avx2)',
+    'cfg(chacha20_force_soft)',
+    'cfg(chacha20_force_sse2)',
+    'cfg(chacha20_force_avx2)',
 ]
 
 [lints.clippy]

--- a/salsa20/Cargo.toml
+++ b/salsa20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa20"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
Releases the following:
- `chacha20` v0.10.0-rc.1
- `salsa20` v0.11.0-rc.1