### PR TITLE
adding the proper features for using legacy/djb construction

### DIFF
--- a/chacha20/src/variants.rs
+++ b/chacha20/src/variants.rs
@@ -53,13 +53,13 @@ impl Variant for Ietf {
 }
 
 /// DJB variant specific features: 64-bit counter and 64-bit nonce.
-#[cfg(feature = "legacy")]
+#[cfg(any(feature = "legacy", feature = "rng"))]
 pub enum Legacy {}
 
-#[cfg(feature = "legacy")]
+#[cfg(any(feature = "legacy", feature = "rng"))]
 impl sealed::Sealed for Legacy {}
 
-#[cfg(feature = "legacy")]
+#[cfg(any(feature = "legacy", feature = "rng"))]
 impl Variant for Legacy {
     type Counter = u64;
 


### PR DESCRIPTION
Fixes #454 

If XChaCha is supposed to use the legacy/djb construction then we might need to add `xchacha` into the mix.