### PR TITLE
chacha20: remove `serde` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,8 +61,6 @@ dependencies = [
  "proptest",
  "rand_chacha",
  "rand_core",
- "serde",
- "serde_json",
  "zeroize",
 ]
 
@@ -165,12 +163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,12 +179,6 @@ name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
-
-[[package]]
-name = "memchr"
-version = "2.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "num-traits"
@@ -354,50 +340,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
 name = "salsa20"
 version = "0.11.0-rc.1"
 dependencies = [
  "cfg-if",
  "cipher",
  "hex-literal",
-]
-
-[[package]]
-name = "serde"
-version = "1.0.219"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.219"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.142"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
 ]
 
 [[package]]

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -22,7 +22,6 @@ rand_core-compatible RNGs based on those ciphers.
 cfg-if = "1"
 cipher = { version = "0.5.0-rc.1", optional = true, features = ["stream-wrapper"] }
 rand_core = { version = "0.9", optional = true, default-features = false }
-serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 
 # `zeroize` is an explicit dependency because this crate may be used without the `cipher` crate
 zeroize = { version = "1.8.1", optional = true, default-features = false }
@@ -35,7 +34,6 @@ cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 proptest = "1"
 rand_chacha = "0.9"
-serde_json = "1.0" # Only to test serde
 
 [features]
 default = ["cipher"]


### PR DESCRIPTION
See discussion from: rust-random/rand#1101

Being able to easily serialize the state of a cryptographic RNG is a footgun that risks both duplicating the keystream (which can lead to e.g. nonce reuse) or exposing it.