### PR TITLE
chacha20: apply `unreachable_pub` lint

### DIFF
--- a/.github/workflows/chacha20.yml
+++ b/.github/workflows/chacha20.yml
@@ -17,8 +17,8 @@ env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-Dwarnings"
   # NOTE: The mirror number changes with each version so keep these in sync
-  SDE_FULL_VERSION_MIRROR: "859732"
-  SDE_FULL_VERSION: "9.58.0-2025-06-16"
+  SDE_FULL_VERSION_MIRROR: "915934"
+  SDE_FULL_VERSION: "10.8.0-2026-03-15"
 
 jobs:
   build:

--- a/.github/workflows/chacha20.yml
+++ b/.github/workflows/chacha20.yml
@@ -79,6 +79,9 @@ jobs:
 
   # Tests for the AVX-512 backend
   avx512:
+    # It looks like Intel blocks `curl` downloads, so the job is disabled
+    # until a fix is found
+    if: false
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -90,9 +93,6 @@ jobs:
       CARGO_INCREMENTAL: 0
       RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
     steps:
-      # It looks like Intel blocks `curl` downloads, so the job is disabled
-      # until a fix is found
-      - if: false
       - uses: actions/checkout@v6
       - name: Install Intel SDE
         run: |

--- a/.github/workflows/chacha20.yml
+++ b/.github/workflows/chacha20.yml
@@ -17,8 +17,8 @@ env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-Dwarnings"
   # NOTE: The mirror number changes with each version so keep these in sync
-  SDE_FULL_VERSION_MIRROR: "915934"
-  SDE_FULL_VERSION: "10.8.0-2026-03-15"
+  SDE_FULL_VERSION_MIRROR: "859732"
+  SDE_FULL_VERSION: "9.58.0-2025-06-16"
 
 jobs:
   build:
@@ -90,6 +90,9 @@ jobs:
       CARGO_INCREMENTAL: 0
       RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
     steps:
+      # It looks like Intel blocks `curl` downloads, so the job is disabled
+      # until a fix is found
+      - if: false
       - uses: actions/checkout@v6
       - name: Install Intel SDE
         run: |

--- a/chacha20/CHANGELOG.md
+++ b/chacha20/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.1 (UNRELEASED)
+### Added
+- `ChaCha20LegacyCore` type and `Nonce` type alias ([#570])
+
+[#570]: https://github.com/RustCrypto/stream-ciphers/pull/570
+
 ## 0.10.0 (2026-02-07)
 ### Added
 - `rand_core` v0.10 support ([#333], [#513])

--- a/chacha20/Cargo.toml
+++ b/chacha20/Cargo.toml
@@ -45,6 +45,7 @@ missing_debug_implementations = "warn"
 missing_docs = "warn"
 trivial_casts = "warn"
 trivial_numeric_casts = "warn"
+unreachable_pub = "warn"
 unused_lifetimes = "warn"
 unused_qualifications = "warn"
 

--- a/chacha20/src/chacha.rs
+++ b/chacha20/src/chacha.rs
@@ -1,4 +1,4 @@
-pub use cipher::{
+use cipher::{
     IvSizeUser, KeyIvInit, KeySizeUser, StreamCipherCoreWrapper,
     array::Array,
     consts::{U12, U32, U64},

--- a/chacha20/src/legacy.rs
+++ b/chacha20/src/legacy.rs
@@ -1,7 +1,6 @@
 //! Legacy version of ChaCha20 with a 64-bit nonce
 
-use crate::chacha::Key;
-use crate::{ChaChaCore, R20};
+use crate::{ChaChaCore, Key, R20, variants::Legacy};
 use cipher::{
     IvSizeUser, KeyIvInit, KeySizeUser, StreamCipherCoreWrapper,
     array::Array,
@@ -10,7 +9,6 @@ use cipher::{
 
 /// Nonce type used by [`ChaCha20Legacy`].
 pub type LegacyNonce = Array<u8, U8>;
-use crate::variants::Legacy;
 
 /// The ChaCha20 stream cipher (legacy "djb" construction with 64-bit nonce).
 pub type ChaCha20Legacy = StreamCipherCoreWrapper<ChaCha20LegacyCore>;

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -31,7 +31,7 @@ pub use rand_core;
 #[cfg(feature = "rng")]
 pub use rng::{ChaCha8Rng, ChaCha12Rng, ChaCha20Rng, Seed, SerializedRngState};
 #[cfg(feature = "xchacha")]
-pub use xchacha::{XChaCha8, XChaCha12, XChaCha20, XKey, XNonce, hchacha};
+pub use xchacha::{XChaCha8, XChaCha12, XChaCha20, XNonce, hchacha};
 
 use cfg_if::cfg_if;
 use core::{fmt, marker::PhantomData};

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -19,17 +19,19 @@ mod rng;
 mod xchacha;
 
 #[cfg(feature = "cipher")]
-pub use chacha::{ChaCha8, ChaCha12, ChaCha20, Key, KeyIvInit};
+pub use chacha::{ChaCha8, ChaCha12, ChaCha20, Key, Nonce};
 #[cfg(feature = "cipher")]
 pub use cipher;
+#[cfg(feature = "cipher")]
+pub use cipher::KeyIvInit;
 #[cfg(feature = "legacy")]
-pub use legacy::{ChaCha20Legacy, LegacyNonce};
+pub use legacy::{ChaCha20Legacy, ChaCha20LegacyCore, LegacyNonce};
 #[cfg(feature = "rng")]
 pub use rand_core;
 #[cfg(feature = "rng")]
 pub use rng::{ChaCha8Rng, ChaCha12Rng, ChaCha20Rng, Seed, SerializedRngState};
 #[cfg(feature = "xchacha")]
-pub use xchacha::{XChaCha8, XChaCha12, XChaCha20, XNonce, hchacha};
+pub use xchacha::{XChaCha8, XChaCha12, XChaCha20, XKey, XNonce, hchacha};
 
 use cfg_if::cfg_if;
 use core::{fmt, marker::PhantomData};

--- a/chacha20/src/xchacha.rs
+++ b/chacha20/src/xchacha.rs
@@ -1,7 +1,7 @@
 //! XChaCha is an extended nonce variant of ChaCha
 
 use crate::{
-    CONSTANTS, ChaChaCore, R8, R12, R20, Rounds, STATE_WORDS, quarter_round, variants::Ietf,
+    CONSTANTS, ChaChaCore, Key, R8, R12, R20, Rounds, STATE_WORDS, quarter_round, variants::Ietf,
 };
 use cipher::{
     BlockSizeUser, IvSizeUser, KeyIvInit, KeySizeUser, StreamCipherClosure, StreamCipherCore,
@@ -12,9 +12,6 @@ use cipher::{
 
 #[cfg(feature = "zeroize")]
 use zeroize::ZeroizeOnDrop;
-
-/// Key type used by all ChaCha variants.
-pub type XKey = Array<u8, U32>;
 
 /// Nonce type used by XChaCha variants.
 pub type XNonce = Array<u8, U24>;
@@ -57,7 +54,7 @@ impl<R: Rounds> BlockSizeUser for XChaChaCore<R> {
 }
 
 impl<R: Rounds> KeyIvInit for XChaChaCore<R> {
-    fn new(key: &XKey, iv: &XNonce) -> Self {
+    fn new(key: &Key, iv: &XNonce) -> Self {
         #[allow(clippy::unwrap_used)]
         let subkey = hchacha::<R>(key, iv[..16].as_ref().try_into().unwrap());
 
@@ -113,7 +110,7 @@ impl<R: Rounds> ZeroizeOnDrop for XChaChaCore<R> {}
 ///
 /// <http://cr.yp.to/snuffle/xsalsa-20110204.pdf>
 #[must_use]
-pub fn hchacha<R: Rounds>(key: &XKey, input: &Array<u8, U16>) -> Array<u8, U32> {
+pub fn hchacha<R: Rounds>(key: &Key, input: &Array<u8, U16>) -> Array<u8, U32> {
     let mut state = [0u32; STATE_WORDS];
     state[..4].copy_from_slice(&CONSTANTS);
 

--- a/chacha20/src/xchacha.rs
+++ b/chacha20/src/xchacha.rs
@@ -14,7 +14,7 @@ use cipher::{
 use zeroize::ZeroizeOnDrop;
 
 /// Key type used by all ChaCha variants.
-pub type Key = Array<u8, U32>;
+pub type XKey = Array<u8, U32>;
 
 /// Nonce type used by XChaCha variants.
 pub type XNonce = Array<u8, U24>;
@@ -57,7 +57,7 @@ impl<R: Rounds> BlockSizeUser for XChaChaCore<R> {
 }
 
 impl<R: Rounds> KeyIvInit for XChaChaCore<R> {
-    fn new(key: &Key, iv: &XNonce) -> Self {
+    fn new(key: &XKey, iv: &XNonce) -> Self {
         #[allow(clippy::unwrap_used)]
         let subkey = hchacha::<R>(key, iv[..16].as_ref().try_into().unwrap());
 
@@ -113,7 +113,7 @@ impl<R: Rounds> ZeroizeOnDrop for XChaChaCore<R> {}
 ///
 /// <http://cr.yp.to/snuffle/xsalsa-20110204.pdf>
 #[must_use]
-pub fn hchacha<R: Rounds>(key: &Key, input: &Array<u8, U16>) -> Array<u8, U32> {
+pub fn hchacha<R: Rounds>(key: &XKey, input: &Array<u8, U16>) -> Array<u8, U32> {
     let mut state = [0u32; STATE_WORDS];
     state[..4].copy_from_slice(&CONSTANTS);
 


### PR DESCRIPTION
Re-exports `Nonce` and `ChaCha20LegacyCore`.

In a future breaking release we probable should just make `legacy`, `rng`, and `xchacha` modules public instead of re-exporting them.

Closes #569