### PR TITLE
[Draft] Implement a fast-key-erasure ChaCha variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,8 +117,7 @@ dependencies = [
 [[package]]
 name = "rand_core"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+source = "git+https://github.com/rust-random/rand_core.git?rev=45fb1f9609a874e146a118bb9c697e96293d6cad#45fb1f9609a874e146a118bb9c697e96293d6cad"
 
 [[package]]
 name = "rc4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io.rand_core]
+git = "https://github.com/rust-random/rand_core.git"
+rev = "45fb1f9609a874e146a118bb9c697e96293d6cad"

--- a/chacha20/src/lib.rs
+++ b/chacha20/src/lib.rs
@@ -29,7 +29,10 @@ pub use legacy::{ChaCha20Legacy, ChaCha20LegacyCore, LegacyNonce};
 #[cfg(feature = "rng")]
 pub use rand_core;
 #[cfg(feature = "rng")]
-pub use rng::{ChaCha8Rng, ChaCha12Rng, ChaCha20Rng, Seed, SerializedRngState};
+pub use rng::{
+    ChaCha8Rng, ChaCha12Rng, ChaCha20Rng, FastErasureChaCha8Rng, FastErasureChaCha12Rng,
+    FastErasureChaCha20Rng, FastErasureCore, Seed, SerializedRngState,
+};
 #[cfg(feature = "xchacha")]
 pub use xchacha::{XChaCha8, XChaCha12, XChaCha20, XNonce, hchacha};
 

--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -378,6 +378,7 @@ impl<R: Rounds, V: Variant> Generator for FastErasureCore<R, V> {
     fn generate(&mut self, buffer: &mut [u32; BUFFER_SIZE]) -> usize {
         let _ = self.0.generate(buffer);
         self.0.state[4..12].copy_from_slice(&buffer[0..8]);
+        Self::erase(&mut buffer[0..8]);
         8
     }
 

--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -42,11 +42,12 @@ impl<R: Rounds, V: Variant> SeedableRng for ChaChaCore<R, V> {
 }
 
 impl<R: Rounds, V: Variant> Generator for ChaChaCore<R, V> {
+    type Word = u32;
     type Output = [u32; BUFFER_SIZE];
 
     /// Generates 4 blocks in parallel with avx2 & neon, but merely fills
     /// 4 blocks with sse2 & soft
-    fn generate(&mut self, buffer: &mut [u32; BUFFER_SIZE]) {
+    fn generate(&mut self, buffer: &mut [u32; BUFFER_SIZE]) -> usize {
         cfg_if! {
             if #[cfg(chacha20_backend = "soft")] {
                 backends::soft::Backend(self).gen_ks_blocks(buffer);
@@ -89,6 +90,8 @@ impl<R: Rounds, V: Variant> Generator for ChaChaCore<R, V> {
                 backends::soft::Backend(self).gen_ks_blocks(buffer);
             }
         }
+
+        0
     }
 
     // `Drop` impl of `BlockRng` calls this method and passes reference to

--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -345,3 +345,110 @@ macro_rules! impl_chacha_rng {
 impl_chacha_rng!(ChaCha8Rng, R8);
 impl_chacha_rng!(ChaCha12Rng, R12);
 impl_chacha_rng!(ChaCha20Rng, R20);
+
+/// ChaCha core with fast erasure
+#[derive(Debug)]
+pub struct FastErasureCore<R: Rounds, V: Variant>(ChaChaCore<R, V>);
+
+impl<R: Rounds, V: Variant> Generator for FastErasureCore<R, V> {
+    type Word = u32;
+    type Output = [u32; BUFFER_SIZE];
+
+    // Generate a block, overwriting the seed
+    //
+    // The counter is incremented like usual (i.e. it is not reset).
+    fn generate(&mut self, buffer: &mut [u32; BUFFER_SIZE]) -> usize {
+        let _ = self.0.generate(buffer);
+        self.0.state[4..12].copy_from_slice(&buffer[0..8]);
+        8
+    }
+
+    fn erase(slice: &mut [Self::Word]) {
+        // Zero consumed values. We don't need zeroize to observe the result
+        // since the buffer is not deallocated here.
+        for word in slice {
+            *word = 0;
+        }
+    }
+
+    // drop() method of inner type is called
+}
+
+macro_rules! impl_chacha_rng {
+    ($Rng:ident, $rounds:ident) => {
+        /// A cryptographically secure random number generator with fast key erasure using the ChaCha stream cipher.
+        ///
+        /// See the [crate docs][crate] for more information about the underlying stream cipher.
+        ///
+        /// This RNG implementation uses fast key erasure to provide backtracking resistance. Each
+        /// time a new buffer of results are generated, the first 32 bytes are used to overwrite the
+        /// key. Each time any value is consumed from the buffer, it is overwritten with zero.
+        ///
+        /// # Example
+        ///
+        /// ```rust
+        #[doc = concat!("use chacha20::", stringify!($Rng), ";")]
+        /// use rand_core::{SeedableRng, Rng};
+        ///
+        /// let seed = [42u8; 32];
+        #[doc = concat!("let mut rng = ", stringify!($Rng), "::from_seed(seed);")]
+        ///
+        /// let random_u32 = rng.next_u32();
+        /// let random_u64 = rng.next_u64();
+        ///
+        /// let mut random_bytes = [0u8; 3];
+        /// rng.fill_bytes(&mut random_bytes);
+        /// ```
+        ///
+        /// See the [`rand`](https://docs.rs/rand/) crate for more advanced RNG functionality.
+        pub struct $Rng {
+            core: BlockRng<FastErasureCore<$rounds, Legacy>>,
+        }
+
+        impl SeedableRng for $Rng {
+            type Seed = Seed;
+
+            #[inline]
+            fn from_seed(seed: Self::Seed) -> Self {
+                let core = FastErasureCore(ChaChaCore::new_internal(&seed, &[0u8; 8]));
+                Self {
+                    core: BlockRng::new(core),
+                }
+            }
+        }
+
+        impl TryRng for $Rng {
+            type Error = Infallible;
+
+            #[inline]
+            fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+                Ok(self.core.next_word())
+            }
+            #[inline]
+            fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+                Ok(self.core.next_u64_from_u32())
+            }
+            #[inline]
+            fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+                self.core.fill_bytes(dest);
+                Ok(())
+            }
+        }
+
+        impl TryCryptoRng for $Rng {}
+
+        #[cfg(feature = "zeroize")]
+        impl ZeroizeOnDrop for $Rng {}
+
+        // Custom Debug implementation that does not expose the internal state
+        impl fmt::Debug for $Rng {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                write!(f, concat!(stringify!($Rng), " {{ ... }}"))
+            }
+        }
+    };
+}
+
+impl_chacha_rng!(FastErasureChaCha8Rng, R8);
+impl_chacha_rng!(FastErasureChaCha12Rng, R12);
+impl_chacha_rng!(FastErasureChaCha20Rng, R20);

--- a/chacha20/src/rng.rs
+++ b/chacha20/src/rng.rs
@@ -350,6 +350,24 @@ impl_chacha_rng!(ChaCha20Rng, R20);
 #[derive(Debug)]
 pub struct FastErasureCore<R: Rounds, V: Variant>(ChaChaCore<R, V>);
 
+impl<R: Rounds, V: Variant> SeedableRng for FastErasureCore<R, V> {
+    type Seed = Seed;
+
+    #[inline]
+    fn from_seed(seed: Self::Seed) -> Self {
+        FastErasureCore(ChaChaCore::from_seed(seed))
+    }
+}
+
+impl<R: Rounds, V: Variant> FastErasureCore<R, V> {
+    /// Get the current block position.
+    #[inline(always)]
+    #[must_use]
+    pub fn get_block_pos(&self) -> V::Counter {
+        self.0.get_block_pos()
+    }
+}
+
 impl<R: Rounds, V: Variant> Generator for FastErasureCore<R, V> {
     type Word = u32;
     type Output = [u32; BUFFER_SIZE];


### PR DESCRIPTION
Motivated by https://github.com/rust-random/rand/issues/1826#issuecomment-5344916559, I wanted to see if we *could* support a fast-key-erasure generator. Yes, I believe we can, and without much code.

Performance penalty: 12-13% for 1kiB blocks, 20-25% for single `u32` values.

# Details

There are two parts to this:

1. We overwrite the key using the first 8 (of 64) values from the results buffer after each generation.
2. We overwrite each value consumed from the buffer with zero.

I believe this is all that's required for forward security.

# Reseeding?

As noted [here](https://blog.cr.yp.to/20170723-random.html), forward security (backtracking resistance) arguably has more value than "backward security" (reseeding) since if an attacker has compromised the system state, there is reason to believe they may be able to do so again. On the other hand, periodic reseeding may be useful for other reasons, e.g. if a process is forked without explicit reseeding (i.e. a bug).

Anyway, there is no reason we can't layer one on top of the other.